### PR TITLE
[EN-7623] requete /user/members longue 

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -33,7 +33,6 @@ import {
 
 import {
   getCommonMembersFilterOptions,
-  getRawLastCVVersionWhereOptions,
   lastCVVersionWhereOptions,
   userSearchQuery,
   userSearchQueryRaw,
@@ -76,19 +75,6 @@ export class UsersService {
     });
   }
 
-  async findAllLastCVVersions(): Promise<
-    { candidateId: string; maxVersion: number }[]
-  > {
-    return this.userModel.sequelize.query(
-      `SELECT "CVs"."UserId" as "candidateId", MAX("CVs"."version") as "maxVersion"
-       FROM "CVs"
-       GROUP BY "CVs"."UserId"`,
-      {
-        type: QueryTypes.SELECT,
-      }
-    );
-  }
-
   async findAllCandidateMembers(
     params: {
       limit: number;
@@ -102,24 +88,26 @@ export class UsersService {
     const { filterOptions, replacements } =
       getCommonMembersFilterOptions(restParams);
 
-    const lastCVVersions = await this.findAllLastCVVersions();
-
-    const candidatesIds: { nameAndId: string; userId: string }[] =
+    const candidatesIds: { userId: string }[] =
       await this.userModel.sequelize.query(
         `
         SELECT 
-          DISTINCT("User"."firstName", "User"."id") as "nameAndId",
           "User"."id" as "userId"
 
         FROM "Users" AS "User"
+
         LEFT OUTER JOIN "User_Candidats" AS "candidat" 
           ON "User"."id" = "candidat"."candidatId"
         LEFT OUTER JOIN "CVs" AS "candidat->cvs" 
           ON "candidat"."candidatId" = "candidat->cvs"."UserId" 
-          AND
-          "candidat->cvs"."deletedAt" IS NULL ${getRawLastCVVersionWhereOptions(
-            lastCVVersions
-          )}
+          AND "candidat->cvs"."deletedAt" IS NULL 
+          AND ("UserId", "version") IN (
+            SELECT
+              "CVs"."UserId" AS "candidateId", MAX("CVs"."version") AS "maxVersion" 
+            FROM "CVs"
+            GROUP BY
+              "CVs"."UserId"
+          )
         LEFT OUTER JOIN "CV_BusinessLines" AS "candidat->cvs->businessLines->CVBusinessLine"
           ON "candidat->cvs"."id" = "candidat->cvs->businessLines->CVBusinessLine"."CVId"
         LEFT OUTER JOIN "BusinessLines" AS "candidat->cvs->businessLines" 
@@ -138,7 +126,8 @@ export class UsersService {
           search ? `AND ${userSearchQueryRaw(search, true)}` : ''
         }
 
-        ORDER BY ("User"."firstName", "User"."id") ASC
+        GROUP BY "User"."id"
+        ORDER BY "User"."firstName" ASC
         LIMIT ${limit}
         OFFSET ${offset}
         `,
@@ -226,25 +215,33 @@ export class UsersService {
     const { replacements, filterOptions } =
       getCommonMembersFilterOptions(restParams);
 
-    const coachesIds: { nameAndId: string; userId: string }[] =
+    const coachesIds: { userId: string }[] =
       await this.userModel.sequelize.query(
         `
-            SELECT DISTINCT("User"."firstName", "User"."id") as "nameAndId", "User"."id" as "userId"
-            FROM "Users" as "User"
-                     LEFT OUTER JOIN "User_Candidats" AS "coaches" ON "User"."id" = "coaches"."coachId"
-                     LEFT OUTER JOIN "Users" AS "coaches->candidat"
-                                     ON "coaches"."candidatId" = "coaches->candidat"."id" AND
-                                        ("coaches->candidat"."deletedAt" IS NULL)
-                     LEFT OUTER JOIN "Organizations" AS "coaches->candidat->organization"
-                                     ON "coaches->candidat"."OrganizationId" = "coaches->candidat->organization"."id"
-                     LEFT OUTER JOIN "Organizations" AS "organization" ON "User"."OrganizationId" = "organization"."id"
-            WHERE "User"."deletedAt" IS NULL
-              AND ${filterOptions.join(' AND ')} ${
+        SELECT 
+          "User"."id" as "userId"
+
+        FROM "Users" as "User"
+                     
+        LEFT OUTER JOIN "User_Candidats" AS "coaches" 
+          ON "User"."id" = "coaches"."coachId"
+        LEFT OUTER JOIN "Users" AS "coaches->candidat"
+          ON "coaches"."candidatId" = "coaches->candidat"."id" 
+          AND ("coaches->candidat"."deletedAt" IS NULL)
+        LEFT OUTER JOIN "Organizations" AS "coaches->candidat->organization"
+          ON "coaches->candidat"."OrganizationId" = "coaches->candidat->organization"."id"
+        LEFT OUTER JOIN "Organizations" AS "organization" 
+          ON "User"."OrganizationId" = "organization"."id"
+            
+        WHERE "User"."deletedAt" IS NULL
+          AND ${filterOptions.join(' AND ')} ${
           search ? `AND ${userSearchQueryRaw(search, true)}` : ''
         }
-            ORDER BY ("User"."firstName", "User"."id") ASC
-                LIMIT ${limit}
-            OFFSET ${offset}
+        
+        GROUP BY "User"."id"
+        ORDER BY "User"."firstName" ASC
+        LIMIT ${limit}
+        OFFSET ${offset}
         `,
         {
           type: QueryTypes.SELECT,

--- a/src/users/users.utils.ts
+++ b/src/users/users.utils.ts
@@ -331,27 +331,6 @@ export function userSearchQueryRaw(query = '', withOrganizationName = false) {
   )`;
 }
 
-export function getRawLastCVVersionWhereOptions(
-  maxVersions: {
-    candidateId: string;
-    maxVersion: number;
-  }[]
-) {
-  if (maxVersions && maxVersions.length > 0) {
-    return `
-      AND ("UserId","version") IN (
-        ${maxVersions
-          .map(({ candidateId, maxVersion }) => {
-            return `('${candidateId}','${maxVersion}')`;
-          })
-          .join(',')}
-        )
-    `;
-  }
-
-  return '';
-}
-
 export const lastCVVersionWhereOptions: WhereOptions<UserCandidat> = {
   version: {
     [Op.in]: [


### PR DESCRIPTION
La query entiere en prod faisait plus de 1200 lignes dont au moins 1100 etaient des couples (userId, CVVersion) a envoyer dans un IN ()
La requête des CVVersions est maintenant fait au sein de la requete principale avec d'autres optimisations 
Passage de 10s a 500ms 
A confirmer une fois en production 