### PR TITLE
[EN-7789] Creation de script d'initiasation db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ lerna-debug.log*
 !.env.dist
 package-lock.json
 .vscode
+
+# Generated files
+create_database_structure?*.sql

--- a/dump-db-schema.sh
+++ b/dump-db-schema.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Il faut avoir postgresql@16 installé sur votre machine pour pouvoir exécuter ce script.
+# Sur mac: brew install postgresql@16
+# puis pg_dump --version
+
+# Définir les variables de connexion à la base de données
+DB_HOST="localhost"      # Hôte de la base de données
+DB_PORT="5432"           # Port de la base de données
+DB_NAME="dbname"         # Nom de la base de données
+DB_USER="dbuser"         # Nom d'utilisateur pour se connecter à la base
+DB_PASSWORD="dbpassword" # Mot de passe de l'utilisateur
+
+# Obtenir la date du jour au format YYYY-MM-DD
+DATE=$(date +%Y-%m-%d)
+
+# Nom du fichier de sortie, incluant la date
+OUTPUT_FILE="create_database_structure_$DATE.sql"
+
+# Exporter la variable d'environnement PGPASSWORD pour éviter d'être invité à entrer le mot de passe
+export PGPASSWORD=$DB_PASSWORD
+
+# Utilisation de pg_dump pour générer le script de la structure sans les données
+# Rediriger la sortie d'erreur vers la sortie standard pour qu'elle soit affichée dans la console
+pg_dump -h $DB_HOST -p $DB_PORT -U $DB_USER -s -f $OUTPUT_FILE $DB_NAME
+
+# Vérification si le dump a réussi
+if [ $? -eq 0 ]; then
+  echo "Le script de création de la structure de la base de données a été généré dans le fichier $OUTPUT_FILE."
+else
+  echo "Une erreur est survenue lors de la génération du script."
+fi
+
+# Supprimer la variable d'environnement PGPASSWORD après utilisation
+unset PGPASSWORD

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "db:migrate": "sequelize db:migrate",
     "db:migrate:undo": "sequelize db:migrate:undo",
     "db:seed": "sequelize db:seed:all",
+    "db:dump": "./dump-db-schema.sh",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
- Sequelize CLI ne permet pas de recreer un modele .sql a partir des modeles d'evolutions 
- Le script est disponible via une commande yarn 
- Besoin d'avoir pg_dump comme décri dans le script 
- Attention a ne pas laisser des secrets dans le fichier et le commit. Je ne voulais pas utiliser le fichier d'env comme ca c'est plus simple pour générer depuis differents environnements. Si tu vois une meilleure solution je prend 