### PR TITLE
fix(Messaging): send message with only a file without content

### DIFF
--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -75,7 +75,7 @@ export class MessagingController {
         'Vous ne pouvez pas participer à cette conversation.'
       );
     }
-    if (files.length <= 0 && createMessageDto.content.length < 1) {
+    if ((!files || files.length <= 0) && createMessageDto.content.length <= 0) {
       throw new BadRequestException(
         'Le message doit contenir au moins un caractère.'
       );

--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -75,7 +75,7 @@ export class MessagingController {
         'Vous ne pouvez pas participer à cette conversation.'
       );
     }
-    if (createMessageDto.content.length < 1) {
+    if (files.length <= 0 && createMessageDto.content.length < 1) {
       throw new BadRequestException(
         'Le message doit contenir au moins un caractère.'
       );


### PR DESCRIPTION
Concernant la review fonctionnel d'Alex sur le ticket EN-7980.
Il souhaite donner la possibilité de créer un message avec uniquement un fichier sans contenu.