### PR TITLE
fix: disable db sync

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -78,7 +78,7 @@ export function getSequelizeOptions(): SequelizeModuleOptions {
     password: password,
     database: pathname.replace('/', ''),
     autoLoadModels: true,
-    synchronize: true,
+    // synchronize: true,
     logging: false,
   };
 }


### PR DESCRIPTION
**💬 Commentaire :**

> ChatGPT à propos de synchronize:true

L’option [synchronize: true](vscode-file://vscode-app/c:/Users/Guillaume/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) dans la configuration Sequelize (ou TypeORM) indique au framework d’automatiquement synchroniser le schéma de la base de données avec tes modèles à chaque démarrage de l’application.
Concrètement :
Si tu ajoutes, modifies ou supprimes des colonnes dans tes modèles, Sequelize va essayer d’appliquer ces changements directement sur la base (création de tables, ajout de colonnes, etc.).
Cela facilite le développement, car tu n’as pas besoin de lancer manuellement des migrations pour chaque modification de modèle.
Attention :
En production, il est fortement déconseillé de laisser [synchronize: true](vscode-file://vscode-app/c:/Users/Guillaume/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), car cela peut entraîner des pertes de données ou des modifications non contrôlées du schéma.
En général, on utilise [synchronize: true](vscode-file://vscode-app/c:/Users/Guillaume/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) uniquement en développement ou en test, et on gère le schéma en production via des migrations.
Résumé :
[synchronize: true](vscode-file://vscode-app/c:/Users/Guillaume/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) = synchronisation automatique du schéma DB avec les modèles à chaque démarrage.
À désactiver en production !