### PR TITLE
Remove event references from nudges and associated tests

### DIFF
--- a/src/db/seeders/20250411141610-insert-nudges.js
+++ b/src/db/seeders/20250411141610-insert-nudges.js
@@ -34,15 +34,6 @@ module.exports = {
         nameOffer: 'Partager mon réseau professionnel',
         order: 3,
       },
-      {
-        id: uuid.v4(),
-        value: 'event',
-        nameRequest:
-          'Se rencontrer et échanger avec les membres de la communauté',
-        nameOffer:
-          'Se rencontrer lors d’événements avec les membres de la communauté',
-        order: 4,
-      },
     ]);
   },
 

--- a/src/db/seeders/20250416000000-insert-discovery-nudge.js
+++ b/src/db/seeders/20250416000000-insert-discovery-nudge.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const uuid = require('uuid');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.bulkInsert('Nudges', [
+      {
+        id: uuid.v4(),
+        value: 'discovery',
+        nameRequest: "Découvrir un métier qui m'attire",
+        nameOffer: 'Faire découvrir mon métier',
+        order: 4,
+      },
+    ]);
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.bulkDelete('Nudges', { value: 'discovery' }, {});
+  },
+};

--- a/src/user-profiles/user-profiles.types.ts
+++ b/src/user-profiles/user-profiles.types.ts
@@ -5,7 +5,7 @@ export enum ContactTypeEnum {
   PHYSICAL = 'physical',
 }
 
-export type HelpValue = 'tips' | 'interview' | 'cv' | 'network' | 'event';
+export type HelpValue = 'tips' | 'interview' | 'cv' | 'network';
 
 export const HelpFilters: FilterConstant<HelpValue>[] = [
   {
@@ -19,10 +19,6 @@ export const HelpFilters: FilterConstant<HelpValue>[] = [
   {
     value: 'cv',
     label: 'CV',
-  },
-  {
-    value: 'event',
-    label: 'Événement',
   },
   {
     value: 'network',

--- a/tests/nudges/nudges.helper.ts
+++ b/tests/nudges/nudges.helper.ts
@@ -47,10 +47,6 @@ export class NudgesHelper {
         value: 'network',
         order: 3,
       },
-      {
-        value: 'event',
-        order: 4,
-      },
     ];
 
     try {

--- a/tests/user-profiles/user-profiles.e2e-spec.ts
+++ b/tests/user-profiles/user-profiles.e2e-spec.ts
@@ -62,7 +62,6 @@ describe('UserProfiles', () => {
   let nudgeTips: Nudge;
   let nudgeNetwork: Nudge;
   let nudgeInterview: Nudge;
-  let nudgeEvent: Nudge;
 
   let contractCdi: Contract;
   let contractCdd: Contract;
@@ -140,7 +139,6 @@ describe('UserProfiles', () => {
     nudgeTips = await nudgesHelper.findOne({ value: 'tips' });
     nudgeNetwork = await nudgesHelper.findOne({ value: 'network' });
     nudgeInterview = await nudgesHelper.findOne({ value: 'interview' });
-    nudgeEvent = await nudgesHelper.findOne({ value: 'event' });
 
     // Initialize the contracts
     await contractHelper.deleteAllContracts();
@@ -1082,7 +1080,7 @@ describe('UserProfiles', () => {
               },
               {
                 userProfile: {
-                  nudges: [{ id: nudgeInterview.id }, { id: nudgeEvent.id }],
+                  nudges: [{ id: nudgeInterview.id }, { id: nudgeCv.id }],
                 },
               }
             );
@@ -1121,7 +1119,7 @@ describe('UserProfiles', () => {
               },
               {
                 userProfile: {
-                  nudges: [{ id: nudgeInterview.id }, { id: nudgeEvent.id }],
+                  nudges: [{ id: nudgeInterview.id }, { id: nudgeCv.id }],
                 },
               }
             );
@@ -1178,7 +1176,7 @@ describe('UserProfiles', () => {
               },
               {
                 userProfile: {
-                  nudges: [{ id: nudgeInterview.id }, { id: nudgeEvent.id }],
+                  nudges: [{ id: nudgeInterview.id }, { id: nudgeCv.id }],
                 },
               }
             );
@@ -1217,7 +1215,7 @@ describe('UserProfiles', () => {
               },
               {
                 userProfile: {
-                  nudges: [{ id: nudgeInterview.id }, { id: nudgeEvent.id }],
+                  nudges: [{ id: nudgeInterview.id }, { id: nudgeCv.id }],
                 },
               }
             );


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9102](https://entourage-asso.atlassian.net/browse/EN-9102)
**🚧 PR-Front :** [front/XXX](https://github.com/ReseauEntourage/entourage-job-front/pull/XXX)
**💬 Commentaire :**

This pull request removes the `event` nudge from the codebase and replaces it with a new `discovery` nudge. It updates the relevant seeders, types, filters, and tests to reflect this change, ensuring that the application and tests no longer reference the obsolete `event` nudge.

**Nudge data and seeders:**
- Removed the `event` nudge from the `Nudges` seed data and added a new `discovery` nudge with appropriate labels and order (`src/db/seeders/20250411141610-insert-nudges.js`, `src/db/seeders/20250416000000-insert-discovery-nudge.js`). [[1]](diffhunk://#diff-2173b87e5303381b2e0562348f90bc89a894a233a479f38dbbb45b2c0f2cf21aL37-L45) [[2]](diffhunk://#diff-fe719b320ff9f7448bfe57954a640d26b309b2ef53e82f325f42678b301b77aaR1-R22)

**Types and filters:**
- Removed `'event'` from the `HelpValue` type and from the `HelpFilters` array, so it's no longer a selectable option in the application (`src/user-profiles/user-profiles.types.ts`). [[1]](diffhunk://#diff-431bb8c8966c2e38ad50f04a2a9be451b36f9745eebb612298d8e9b9577716abL8-R8) [[2]](diffhunk://#diff-431bb8c8966c2e38ad50f04a2a9be451b36f9745eebb612298d8e9b9577716abL23-L26)

**Test data and usage:**
- Removed all references to the `event` nudge from test helpers and test cases, including the `NudgesHelper` seed data and the `user-profiles.e2e-spec.ts` test suite (`tests/nudges/nudges.helper.ts`, `tests/user-profiles/user-profiles.e2e-spec.ts`). [[1]](diffhunk://#diff-3d0a075cc0c5b56d91e1688259d726b68d8946046ae160abf5bda191c632e5f3L50-L53) [[2]](diffhunk://#diff-7511523e7ec577afe33e8925b8f708bc9a52389f8136e2189b7a93260fd33e7fL65) [[3]](diffhunk://#diff-7511523e7ec577afe33e8925b8f708bc9a52389f8136e2189b7a93260fd33e7fL143)

**Test logic updates:**
- Updated test cases to use the `cv` nudge instead of the removed `event` nudge, ensuring all tests remain valid and relevant (`tests/user-profiles/user-profiles.e2e-spec.ts`). [[1]](diffhunk://#diff-7511523e7ec577afe33e8925b8f708bc9a52389f8136e2189b7a93260fd33e7fL1085-R1083) [[2]](diffhunk://#diff-7511523e7ec577afe33e8925b8f708bc9a52389f8136e2189b7a93260fd33e7fL1124-R1122) [[3]](diffhunk://#diff-7511523e7ec577afe33e8925b8f708bc9a52389f8136e2189b7a93260fd33e7fL1181-R1179) [[4]](diffhunk://#diff-7511523e7ec577afe33e8925b8f708bc9a52389f8136e2189b7a93260fd33e7fL1220-R1218)

[EN-9102]: https://entourage-asso.atlassian.net/browse/EN-9102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ