### PR TITLE
Add additional fields for referred users and include conversations

### DIFF
--- a/src/current-user/dto/current-user-referred-users.dto.ts
+++ b/src/current-user/dto/current-user-referred-users.dto.ts
@@ -30,10 +30,10 @@ export const generateCurrentUserReferredUsersDto = (
       email: candidate.email,
       coachesContactedCount: conversations.length,
       referredAt: candidate.createdAt
-        ? new Date(candidate.createdAt).toLocaleDateString('fr')
+        ? new Date(candidate.createdAt).toLocaleDateString('fr-FR')
         : null,
       onboardingCompletedAt: candidate.onboardingCompletedAt
-        ? new Date(candidate.onboardingCompletedAt).toLocaleDateString('fr')
+        ? new Date(candidate.onboardingCompletedAt).toLocaleDateString('fr-FR')
         : null,
     };
   }),

--- a/src/current-user/dto/current-user-referred-users.dto.ts
+++ b/src/current-user/dto/current-user-referred-users.dto.ts
@@ -9,7 +9,7 @@ export interface CurrentUserReferredUserDto {
   email: string;
   coachesContactedCount: number;
   referredAt: string | null;
-  accountCreatedAt: string | null;
+  onboardingCompletedAt: string | null;
 }
 
 export interface CurrentUserReferredUsersDto {
@@ -32,7 +32,7 @@ export const generateCurrentUserReferredUsersDto = (
       referredAt: candidate.createdAt
         ? new Date(candidate.createdAt).toLocaleDateString('fr')
         : null,
-      accountCreatedAt: candidate.onboardingCompletedAt
+      onboardingCompletedAt: candidate.onboardingCompletedAt
         ? new Date(candidate.onboardingCompletedAt).toLocaleDateString('fr')
         : null,
     };

--- a/src/current-user/dto/current-user-referred-users.dto.ts
+++ b/src/current-user/dto/current-user-referred-users.dto.ts
@@ -1,3 +1,4 @@
+import { Conversation } from 'src/messaging/models';
 import { User } from 'src/users/models';
 
 export interface CurrentUserReferredUserDto {
@@ -5,6 +6,10 @@ export interface CurrentUserReferredUserDto {
   firstName: string;
   lastName: string;
   role: string;
+  email: string;
+  coachesContactedCount: number;
+  referredAt: string | null;
+  accountCreatedAt: string | null;
 }
 
 export interface CurrentUserReferredUsersDto {
@@ -14,10 +19,22 @@ export interface CurrentUserReferredUsersDto {
 export const generateCurrentUserReferredUsersDto = (
   user: User
 ): CurrentUserReferredUsersDto => ({
-  referredCandidates: (user.referredCandidates || []).map((candidate) => ({
-    id: candidate.id,
-    firstName: candidate.firstName,
-    lastName: candidate.lastName,
-    role: candidate.role,
-  })),
+  referredCandidates: (user.referredCandidates || []).map((candidate) => {
+    const conversations =
+      (candidate.conversations as Conversation[] | undefined) ?? [];
+    return {
+      id: candidate.id,
+      firstName: candidate.firstName,
+      lastName: candidate.lastName,
+      role: candidate.role,
+      email: candidate.email,
+      coachesContactedCount: conversations.length,
+      referredAt: candidate.createdAt
+        ? new Date(candidate.createdAt).toLocaleDateString('fr')
+        : null,
+      accountCreatedAt: candidate.onboardingCompletedAt
+        ? new Date(candidate.onboardingCompletedAt).toLocaleDateString('fr')
+        : null,
+    };
+  }),
 });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -215,7 +215,23 @@ export class UsersService {
         {
           model: User,
           as: 'referredCandidates',
-          attributes: ['id', 'firstName', 'lastName', 'role'],
+          attributes: [
+            'id',
+            'firstName',
+            'lastName',
+            'role',
+            'email',
+            'createdAt',
+            'onboardingCompletedAt',
+          ],
+          include: [
+            {
+              model: Conversation,
+              as: 'conversations',
+              attributes: ['id'],
+              required: false,
+            },
+          ],
         },
       ],
     });


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9090](https://entourage-asso.atlassian.net/browse/EN-9090)
**🚧 PR-Front :** [front/XXX](https://github.com/ReseauEntourage/entourage-job-front/pull/XXX)
**💬 Commentaire :**

This pull request enhances the data returned for referred users by including additional details and related conversation information. The main improvements are in the data transfer objects and the user service, allowing for richer information about each referred candidate.

**Enhancements to referred user data:**

* The `CurrentUserReferredUserDto` interface now includes `email`, `coachesContactedCount`, `referredAt`, and `accountCreatedAt` fields, providing more comprehensive information for each referred user.
* The `generateCurrentUserReferredUsersDto` function has been updated to calculate `coachesContactedCount` based on the number of associated conversations, and to format the `referredAt` and `accountCreatedAt` dates.

**Database query and model improvements:**

* The `UsersService` now fetches additional attributes (`email`, `createdAt`, `onboardingCompletedAt`) for referred candidates and includes their related `conversations` (with just the `id`), enabling the new data fields to be populated in the DTO.

[EN-9090]: https://entourage-asso.atlassian.net/browse/EN-9090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ