### PR TITLE
Integrate LLM metrics tracking and configure Datadog for performance

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -159,3 +159,13 @@ ANTHROPIC_API_KEY=
 
 # Bull
 QUEUES_ADMIN_PASSWORD=
+
+# Datadog
+DD_API_KEY=
+DD_APM_ENABLED=false
+DD_LOGS_ENABLED=false
+DD_TRACE_ENABLED=false
+DD_ENV=development
+DD_SERVICE=entourage-job-back
+DD_TRACE_SAMPLE_RATE=1.0
+DD_SITE=datadoghq.eu

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -23,6 +23,7 @@ services:
       DB_USER: entourage_pro
       DB_PASSWORD: entourage_pro
       DB_NAME: entourage_pro
+      DD_AGENT_HOST: datadog
     depends_on:
       - db
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       DB_USER: entourage_pro
       DB_PASSWORD: entourage_pro
       DB_NAME: entourage_pro
+      DD_AGENT_HOST: datadog
     depends_on:
       - db
       - redis
@@ -50,6 +51,29 @@ services:
       - 'log_temp_files=10240'
       - '-c'
       - 'shared_buffers=3GB'
+  ## DATADOG AGENT
+  datadog:
+    container_name: datadog
+    image: datadog/agent:latest
+    restart: always
+    environment:
+      DD_API_KEY: ${DD_API_KEY}
+      DD_SITE: ${DD_SITE:-datadoghq.eu}
+      DD_APM_ENABLED: true
+      DD_APM_NON_LOCAL_TRAFFIC: true
+      DD_LOGS_ENABLED: true
+      DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: true
+      DD_CONTAINER_EXCLUDE: 'name:datadog'
+      DD_DOGSTATSD_NON_LOCAL_TRAFFIC: true
+    ports:
+      - '8125:8125/udp'
+      - '8126:8126'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+      - ./docker/datadog/conf.d:/etc/datadog-agent/conf.d
+
   ## ENTOURAGE PRO BACKEND CACHE
   redis:
     container_name: redis

--- a/docker/datadog/conf.d/redisdb.d/conf.yaml
+++ b/docker/datadog/conf.d/redisdb.d/conf.yaml
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+  - host: redis
+    port: 6379
+    password: eYVX7EwVmmxKPCDmwMtyKVge8oLd2t81

--- a/src/ai-assistant/ai-assistant.module.ts
+++ b/src/ai-assistant/ai-assistant.module.ts
@@ -3,6 +3,7 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { Experience } from 'src/common/experiences/models';
 import { Formation } from 'src/common/formations/models';
 import { AnthropicModule } from 'src/external-services/anthropic/anthropic.module';
+import { LlmMetricsModule } from 'src/external-services/llm-metrics/llm-metrics.module';
 import { UserInConversation } from 'src/messaging/guards/user-in-conversation';
 import { MessagingModule } from 'src/messaging/messaging.module';
 import { UserProfile } from 'src/user-profiles/models';
@@ -29,6 +30,7 @@ import { AiAssistantSession } from './models/ai-assistant-session.model';
     ]),
     MessagingModule,
     AnthropicModule,
+    LlmMetricsModule,
     UsersModule,
   ],
   controllers: [AiAssistantController],

--- a/src/ai-assistant/ai-assistant.service.ts
+++ b/src/ai-assistant/ai-assistant.service.ts
@@ -17,6 +17,7 @@ import { Formation } from 'src/common/formations/models';
 import { Occupation } from 'src/common/occupations/models';
 import { Skill } from 'src/common/skills/models';
 import { AnthropicService } from 'src/external-services/anthropic/anthropic.service';
+import { LlmMetricsService } from 'src/external-services/llm-metrics/llm-metrics.service';
 import { MessagingService } from 'src/messaging/messaging.service';
 import { Organization } from 'src/organizations/models';
 import { REDIS_CLIENT } from 'src/redis/redis.module';
@@ -50,6 +51,7 @@ export class AiAssistantService {
     private userProfileModel: typeof UserProfile,
     private messagingService: MessagingService,
     private anthropicService: AnthropicService,
+    private llmMetrics: LlmMetricsService,
     @Inject(REDIS_CLIENT) private readonly redis: Redis
   ) {}
 
@@ -271,6 +273,14 @@ export class AiAssistantService {
         subscriber.next({ data: { content: event.delta.text } });
       }
     }
+
+    const finalMessage = await stream.finalMessage();
+    this.llmMetrics.recordAnthropicUsage(
+      'claude-sonnet-4-6',
+      finalMessage.usage,
+      'stream',
+      'ai_assistant'
+    );
 
     const suggestionRegex = /\[SUGGESTION\]([\s\S]*?)\[\/SUGGESTION\]/g;
     const suggestions: string[] = [];

--- a/src/external-services/anthropic/anthropic.module.ts
+++ b/src/external-services/anthropic/anthropic.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { LlmMetricsModule } from 'src/external-services/llm-metrics/llm-metrics.module';
 import { AnthropicService } from './anthropic.service';
 
 @Module({
+  imports: [LlmMetricsModule],
   providers: [AnthropicService],
   exports: [AnthropicService],
 })

--- a/src/external-services/anthropic/anthropic.service.ts
+++ b/src/external-services/anthropic/anthropic.service.ts
@@ -4,6 +4,7 @@ import {
   TextBlockParam,
 } from '@anthropic-ai/sdk/resources/messages';
 import { Injectable } from '@nestjs/common';
+import { LlmMetricsService } from 'src/external-services/llm-metrics/llm-metrics.service';
 
 @Injectable()
 export class AnthropicService {
@@ -11,7 +12,7 @@ export class AnthropicService {
 
   private readonly MAX_TOKENS = 1024;
 
-  constructor() {
+  constructor(private readonly llmMetrics: LlmMetricsService) {
     this.client = new Anthropic({
       apiKey: process.env.ANTHROPIC_API_KEY,
     });
@@ -38,12 +39,19 @@ export class AnthropicService {
     userMessage: string,
     maxTokens = 5
   ): Promise<string> {
+    const model = 'claude-haiku-4-5-20251001';
     const response = await this.client.messages.create({
-      model: 'claude-haiku-4-5-20251001',
+      model,
       max_tokens: maxTokens,
       system: systemPrompt,
       messages: [{ role: 'user', content: userMessage }],
     });
+    this.llmMetrics.recordAnthropicUsage(
+      model,
+      response.usage,
+      'classify',
+      'ai_assistant'
+    );
     const block = response.content[0];
     return block.type === 'text' ? block.text : '';
   }

--- a/src/external-services/llm-metrics/llm-metrics.module.ts
+++ b/src/external-services/llm-metrics/llm-metrics.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { LlmMetricsService } from './llm-metrics.service';
+
+@Module({
+  providers: [LlmMetricsService],
+  exports: [LlmMetricsService],
+})
+export class LlmMetricsModule {}

--- a/src/external-services/llm-metrics/llm-metrics.service.ts
+++ b/src/external-services/llm-metrics/llm-metrics.service.ts
@@ -1,0 +1,62 @@
+import { Usage } from '@anthropic-ai/sdk/resources/messages/messages';
+import { Injectable, Logger } from '@nestjs/common';
+import { CompletionUsage } from 'openai/resources/completions';
+import { tracer } from 'src/tracer';
+
+@Injectable()
+export class LlmMetricsService {
+  readonly logger = new Logger(LlmMetricsService.name);
+  recordAnthropicUsage(
+    model: string,
+    usage: Usage,
+    operation: string,
+    feature: string
+  ): void {
+    const tags = { model, provider: 'anthropic', operation, feature };
+
+    tracer.dogstatsd.increment('ai.tokens.input', usage.input_tokens, tags);
+    tracer.dogstatsd.increment('ai.tokens.output', usage.output_tokens, tags);
+
+    const cacheReadTokens = usage.cache_read_input_tokens ?? 0;
+    const cacheWriteTokens = usage.cache_creation_input_tokens ?? 0;
+
+    if (cacheReadTokens > 0) {
+      tracer.dogstatsd.increment('ai.tokens.cache_read', cacheReadTokens, tags);
+    }
+    if (cacheWriteTokens > 0) {
+      tracer.dogstatsd.increment(
+        'ai.tokens.cache_write',
+        cacheWriteTokens,
+        tags
+      );
+    }
+
+    tracer.dogstatsd.flush();
+  }
+
+  recordOpenAiUsage(
+    model: string,
+    usage: CompletionUsage,
+    operation: string,
+    feature: string
+  ): void {
+    const tags = { model, provider: 'openai', operation, feature };
+    tracer.dogstatsd.increment('ai.tokens.input', usage.prompt_tokens, tags);
+    tracer.dogstatsd.increment(
+      'ai.tokens.output',
+      usage.completion_tokens,
+      tags
+    );
+    this.logger.debug(
+      `OpenAI usage recorded: ${JSON.stringify({
+        model,
+        operation,
+        feature,
+        prompt_tokens: usage.prompt_tokens,
+        completion_tokens: usage.completion_tokens,
+      })}`
+    );
+
+    tracer.dogstatsd.flush();
+  }
+}

--- a/src/external-services/llm-metrics/llm-metrics.service.ts
+++ b/src/external-services/llm-metrics/llm-metrics.service.ts
@@ -5,7 +5,7 @@ import { tracer } from 'src/tracer';
 
 @Injectable()
 export class LlmMetricsService {
-  readonly logger = new Logger(LlmMetricsService.name);
+  private readonly logger = new Logger(LlmMetricsService.name);
   recordAnthropicUsage(
     model: string,
     usage: Usage,

--- a/src/external-services/openai/openai.module.ts
+++ b/src/external-services/openai/openai.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
+import { LlmMetricsModule } from 'src/external-services/llm-metrics/llm-metrics.module';
 import { OpenAiService } from './openai.service';
 
 @Module({
-  imports: [],
+  imports: [LlmMetricsModule],
   providers: [OpenAiService],
   exports: [OpenAiService],
 })

--- a/src/external-services/openai/openai.service.ts
+++ b/src/external-services/openai/openai.service.ts
@@ -4,14 +4,17 @@ import {
   ChatCompletionContentPart,
   ChatCompletionMessage,
 } from 'openai/resources/chat';
+import { LlmMetricsService } from 'src/external-services/llm-metrics/llm-metrics.service';
 import { cvSchema, CvSchemaType } from './openai.schemas';
+
+const CV_EXTRACTION_MODEL = 'o4-mini-2025-04-16';
 
 @Injectable()
 export class OpenAiService {
   private readonly openai: OpenAI;
   private readonly logger = new Logger(OpenAiService.name);
 
-  constructor() {
+  constructor(private readonly llmMetrics: LlmMetricsService) {
     this.openai = new OpenAI({
       apiKey: process.env.OPENAI_API_KEY,
     });
@@ -42,7 +45,7 @@ export class OpenAiService {
 
     try {
       const response = await this.openai.chat.completions.create({
-        model: 'o4-mini-2025-04-16',
+        model: CV_EXTRACTION_MODEL,
         max_completion_tokens: Number(
           process.env.OPENAI_MAX_COMPLETION_TOKENS ?? 4096
         ),
@@ -98,6 +101,18 @@ export class OpenAiService {
           `Aucun tool_call n'a été retourné par l'API OpenAI (finish_reason=${String(
             finishReason
           )}).`
+        );
+      }
+
+      if (response.usage) {
+        this.logger.debug(
+          `OpenAI usage for CV extraction: ${JSON.stringify(response.usage)}`
+        );
+        this.llmMetrics.recordOpenAiUsage(
+          CV_EXTRACTION_MODEL,
+          response.usage,
+          'cv_extraction',
+          'cv_extraction'
         );
       }
 

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -1,12 +1,8 @@
 import tracer from 'dd-trace';
 
-const ENV = `${process.env.NODE_ENV}`;
-
-if (ENV === 'production') {
-  tracer.init({
-    version: process.env.HEROKU_RELEASE_VERSION,
-  });
-}
+tracer.init({
+  version: process.env.HEROKU_RELEASE_VERSION,
+});
 
 tracer.use('pg', {
   service: 'entourage-pro-backend-postgres',

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,3 +1,5 @@
+import './tracer';
+
 import { NestFactory } from '@nestjs/core';
 import { WorkerModule } from './worker.module';
 


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9177](https://entourage-asso.atlassian.net/browse/EN-9177)
**💬 Commentaire :**
This pull request introduces Datadog integration for application observability and adds a service for tracking and recording LLM (Large Language Model) usage metrics for both Anthropic and OpenAI providers. It updates the environment, Docker, and service configurations to support Datadog, and refactors the AI-related service modules to record token usage for monitoring and analytics.

**Datadog Integration and Observability**

* Added Datadog Agent as a service in `docker-compose.yml` with necessary environment variables and volume mounts; also updated `.env.dist` to include Datadog configuration options. (`docker-compose.yml` [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R54-R76) `.env.dist` [[2]](diffhunk://#diff-84f0ebf34c2eaf5b3b8f8263f855938cef61b0fa67cd0528279daa28ef40a096R162-R171)
* Updated both main and worker Docker Compose files to set the `DD_AGENT_HOST` environment variable for application containers. (`docker-compose.yml` [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R27) `docker-compose.worker.yml` [[2]](diffhunk://#diff-8dbf057654287eabc5842ab93c6a52b6db46a7f0a48e8a21ee14b00fec66e110R26)
* Added Datadog Redis integration configuration to enable Redis monitoring. (`docker/datadog/conf.d/redisdb.d/conf.yaml` [docker/datadog/conf.d/redisdb.d/conf.yamlR1-R6](diffhunk://#diff-14ce6d5fed78765fc4db9750bfea383a9326e5bddb15d06b4ff026c125e4d4b4R1-R6))
* Ensured tracer initialization is always performed, not just in production, and imported the tracer in the worker entrypoint. (`src/tracer.ts` [[1]](diffhunk://#diff-c0dc1332d45b0431c3e930ad9c591ca2d5c0b2e3e0e82777c1bd4ef3bebb6fa2L3-L9) `src/worker.ts` [[2]](diffhunk://#diff-1245a5bbc4ca0684dff978efcae118b08f62d2afc05812df22d0627985b4273aR1-R2)

**LLM Usage Metrics Service**

* Introduced a new `LlmMetricsService` and its module to record and export LLM token usage for Anthropic and OpenAI providers, with support for tagging and DogStatsD metrics. (`src/external-services/llm-metrics/llm-metrics.service.ts` [[1]](diffhunk://#diff-8d08b81c98bbc3765e2f4801b0690cd85cf9f8701d21b5ec156c609ce18d3186R1-R62) `src/external-services/llm-metrics/llm-metrics.module.ts` [[2]](diffhunk://#diff-95f4a8cc6cdd79a00acf2ab409868f983d2e001fea0ca29313a131761e57d284R1-R8)
* Integrated `LlmMetricsModule` into AI assistant, Anthropic, and OpenAI modules to enable usage tracking. (`src/ai-assistant/ai-assistant.module.ts` [[1]](diffhunk://#diff-3e153f6438e6460683468de3e8c1e4d1de24e9f4dd78de7d392d7e62bc72a8d4R6) [[2]](diffhunk://#diff-3e153f6438e6460683468de3e8c1e4d1de24e9f4dd78de7d392d7e62bc72a8d4R33); `src/external-services/anthropic/anthropic.module.ts` [[3]](diffhunk://#diff-0b8bf37fec85109a0e65684a7fa44cd7e4378c2755d4fbff86842429385552fbR2-R6); `src/external-services/openai/openai.module.ts` [[4]](diffhunk://#diff-846fc0ba919af3ce99fb6bfb395b97fa3c3c87807c919a4206da309fe3a0e2fdR2-R6)

**AI Service Refactoring for Usage Metrics**

* Updated `AnthropicService` and `OpenAiService` to record usage metrics after each API call, including model, operation, feature, and token counts. (`src/external-services/anthropic/anthropic.service.ts` [[1]](diffhunk://#diff-db4439a07581d17e80ecc2dace4066e86cc725e7155ae98a4b4b7e1531197654R7-R15) [[2]](diffhunk://#diff-db4439a07581d17e80ecc2dace4066e86cc725e7155ae98a4b4b7e1531197654R42-R54); `src/external-services/openai/openai.service.ts` [[3]](diffhunk://#diff-9f4d2d468bba60ae2edd846be3b1caec831e5caef02282e9e8686c6aae79a4b1R7-R17) [[4]](diffhunk://#diff-9f4d2d468bba60ae2edd846be3b1caec831e5caef02282e9e8686c6aae79a4b1L45-R48) [[5]](diffhunk://#diff-9f4d2d468bba60ae2edd846be3b1caec831e5caef02282e9e8686c6aae79a4b1R107-R118)
* Modified `AiAssistantService` to use `LlmMetricsService` for recording Anthropic usage after streaming completions. (`src/ai-assistant/ai-assistant.service.ts` [[1]](diffhunk://#diff-fb96054fd4253f781d6f643ce17139cb2273557fd1e26abc6d8042a3476cf6dfR20) [[2]](diffhunk://#diff-fb96054fd4253f781d6f643ce17139cb2273557fd1e26abc6d8042a3476cf6dfR54) [[3]](diffhunk://#diff-fb96054fd4253f781d6f643ce17139cb2273557fd1e26abc6d8042a3476cf6dfR277-R284)

These changes collectively enable robust observability and monitoring of LLM usage and application performance via Datadog.

[EN-9177]: https://entourage-asso.atlassian.net/browse/EN-9177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ