### PR TITLE
Share on LinkedIn integration

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -122,6 +122,11 @@ PUSHER_API_KEY=
 # VoyageAI
 VOYAGEAI_API_KEY=
 
+# LinkedIn OAuth (Share on behalf of users)
+LINKEDIN_CLIENT_ID=
+LINKEDIN_CLIENT_SECRET=
+LINKEDIN_REDIRECT_URI=http://localhost:3000/auth/linkedin/callback
+
 # Salesforce (Connected App - OAuth 2.0 Client Credentials Flow)
 ENABLE_SF=false
 SALESFORCE_LOGIN_URL=

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -30,6 +30,7 @@ import { EmbeddingsModule } from './embeddings/embeddings.module';
 import { EventsModule } from './events/events.module';
 import { ExternalCvsModule } from './external-cvs/external-cvs.module';
 import { ExternalDatabasesModule } from './external-databases/external-databases.module';
+import { LinkedInModule } from './external-services/linkedin/linkedin.module';
 import { OpenAiModule } from './external-services/openai/openai.module';
 import { SalesforceModule } from './external-services/salesforce/salesforce.module';
 import { FeatureFlagsModule } from './feature-flags/feature-flags.module';
@@ -146,6 +147,7 @@ export function getSequelizeOptions(
     MailsModule,
     ExternalDatabasesModule,
     SalesforceModule,
+    LinkedInModule,
     ContactsModule,
     OrganizationsModule,
     ReadDocumentsModule,

--- a/src/current-user/dto/current-user-identity.dto.ts
+++ b/src/current-user/dto/current-user-identity.dto.ts
@@ -20,9 +20,14 @@ type CurrentUserIdentityUserKeys =
 
 export type CurrentUserIdentityDto = Pick<User, CurrentUserIdentityUserKeys> & {
   betaFeatures: Record<FeatureKey, boolean>;
+  hasLinkedinLinked: boolean;
 };
 
-export const CurrentUserIdentityAttributes: CurrentUserIdentityUserKeys[] = [
+// linkedinAccessToken is fetched but not exposed in the DTO — only hasLinkedinLinked is returned
+export const CurrentUserIdentityAttributes: (
+  | CurrentUserIdentityUserKeys
+  | 'linkedinAccessToken'
+)[] = [
   'id',
   'firstName',
   'lastName',
@@ -38,6 +43,7 @@ export const CurrentUserIdentityAttributes: CurrentUserIdentityUserKeys[] = [
   'onboardingStatus',
   'onboardingCompletedAt',
   'onboardingWebinarSkippedAt',
+  'linkedinAccessToken',
 ];
 
 export const generateCurrentUserIdentityDto = (
@@ -61,4 +67,5 @@ export const generateCurrentUserIdentityDto = (
   betaFeatures: Object.fromEntries(
     (user.featureFlags ?? []).map((f) => [f.featureKey, f.enabled])
   ) as Record<FeatureKey, boolean>,
+  hasLinkedinLinked: !!user.linkedinAccessToken,
 });

--- a/src/db/migrations/20260518000000-add-linkedin-oauth-to-users.js
+++ b/src/db/migrations/20260518000000-add-linkedin-oauth-to-users.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Users', 'linkedinId', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('Users', 'linkedinAccessToken', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('Users', 'linkedinRefreshToken', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('Users', 'linkedinTokenExpiresAt', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('Users', 'linkedinTokenExpiresAt');
+    await queryInterface.removeColumn('Users', 'linkedinRefreshToken');
+    await queryInterface.removeColumn('Users', 'linkedinAccessToken');
+    await queryInterface.removeColumn('Users', 'linkedinId');
+  },
+};

--- a/src/external-services/linkedin/linkedin.controller.ts
+++ b/src/external-services/linkedin/linkedin.controller.ts
@@ -11,7 +11,7 @@ import {
   Query,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Public, UserPayload } from 'src/auth/guards';
+import { UserPayload } from 'src/auth/guards';
 import { LinkedInService } from './linkedin.service';
 
 @ApiTags('LinkedIn')
@@ -21,21 +21,15 @@ export class LinkedInController {
   constructor(private readonly linkedInService: LinkedInService) {}
 
   @Get('auth/linkedin/url')
-  getOAuthUrl(
-    @UserPayload('id', new ParseUUIDPipe()) userId: string,
-    @Query('redirectAfterShare') redirectAfterShare?: string
-  ) {
-    const state = this.linkedInService.encodeState({
-      userId,
-      redirectAfterShare,
-    });
+  getOAuthUrl(@Query('redirectAfterShare') redirectAfterShare?: string) {
+    const state = this.linkedInService.encodeState({ redirectAfterShare });
     const url = this.linkedInService.buildOAuthUrl(state);
     return { url };
   }
 
-  @Public()
   @Post('auth/linkedin/exchange')
   async exchangeCode(
+    @UserPayload('id', new ParseUUIDPipe()) userId: string,
     @Body('code') code: string,
     @Body('state') state: string
   ): Promise<{ pendingShare?: string }> {
@@ -45,17 +39,13 @@ export class LinkedInController {
 
     const stateData = this.linkedInService.decodeState(state ?? '');
 
-    if (!stateData.userId) {
-      throw new BadRequestException('Invalid state');
-    }
-
     try {
       const tokenData = await this.linkedInService.exchangeCodeForToken(code);
-      await this.linkedInService.storeToken(stateData.userId, tokenData);
+      await this.linkedInService.storeToken(userId, tokenData);
       return { pendingShare: stateData.redirectAfterShare };
     } catch (err) {
       this.logger.error(
-        `LinkedIn token exchange failed for user ${stateData.userId}`,
+        `LinkedIn token exchange failed for user ${userId}`,
         err instanceof Error ? err.stack : JSON.stringify(err)
       );
       throw new BadRequestException('Failed to exchange LinkedIn token');

--- a/src/external-services/linkedin/linkedin.controller.ts
+++ b/src/external-services/linkedin/linkedin.controller.ts
@@ -1,0 +1,79 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Logger,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Public, UserPayload } from 'src/auth/guards';
+import { LinkedInService } from './linkedin.service';
+
+@ApiTags('LinkedIn')
+@Controller()
+export class LinkedInController {
+  private readonly logger = new Logger(LinkedInController.name);
+  constructor(private readonly linkedInService: LinkedInService) {}
+
+  @Get('auth/linkedin/url')
+  getOAuthUrl(
+    @UserPayload('id', new ParseUUIDPipe()) userId: string,
+    @Query('redirectAfterShare') redirectAfterShare?: string
+  ) {
+    const state = this.linkedInService.encodeState({
+      userId,
+      redirectAfterShare,
+    });
+    const url = this.linkedInService.buildOAuthUrl(state);
+    return { url };
+  }
+
+  @Public()
+  @Post('auth/linkedin/exchange')
+  async exchangeCode(
+    @Body('code') code: string,
+    @Body('state') state: string
+  ): Promise<{ pendingShare?: string }> {
+    if (!code) {
+      throw new BadRequestException('Missing authorization code');
+    }
+
+    const stateData = this.linkedInService.decodeState(state ?? '');
+
+    if (!stateData.userId) {
+      throw new BadRequestException('Invalid state');
+    }
+
+    try {
+      const tokenData = await this.linkedInService.exchangeCodeForToken(code);
+      await this.linkedInService.storeToken(stateData.userId, tokenData);
+      return { pendingShare: stateData.redirectAfterShare };
+    } catch (err) {
+      this.logger.error(
+        `LinkedIn token exchange failed for user ${stateData.userId}`,
+        err instanceof Error ? err.stack : JSON.stringify(err)
+      );
+      throw new BadRequestException('Failed to exchange LinkedIn token');
+    }
+  }
+
+  @Delete('auth/linkedin')
+  async unlinkAccount(@UserPayload('id', new ParseUUIDPipe()) userId: string) {
+    await this.linkedInService.unlinkAccount(userId);
+    return { success: true };
+  }
+
+  @Post('linkedin/share/:profileUserId')
+  async shareProfile(
+    @UserPayload('id', new ParseUUIDPipe()) userId: string,
+    @Param('profileUserId', new ParseUUIDPipe()) profileUserId: string
+  ) {
+    await this.linkedInService.shareProfile(userId, profileUserId);
+    return { success: true };
+  }
+}

--- a/src/external-services/linkedin/linkedin.module.ts
+++ b/src/external-services/linkedin/linkedin.module.ts
@@ -1,0 +1,16 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { UserProfilesModule } from 'src/user-profiles/user-profiles.module';
+import { UsersModule } from 'src/users/users.module';
+import { LinkedInController } from './linkedin.controller';
+import { LinkedInService } from './linkedin.service';
+
+@Module({
+  imports: [
+    forwardRef(() => UsersModule),
+    forwardRef(() => UserProfilesModule),
+  ],
+  controllers: [LinkedInController],
+  providers: [LinkedInService],
+  exports: [LinkedInService],
+})
+export class LinkedInModule {}

--- a/src/external-services/linkedin/linkedin.service.ts
+++ b/src/external-services/linkedin/linkedin.service.ts
@@ -16,7 +16,6 @@ const LINKEDIN_POSTS_URL = `${LINKEDIN_API_URL}/rest/posts`;
 const LINKEDIN_API_VERSION = '202604';
 
 export interface LinkedInOAuthState {
-  userId?: string;
   redirectAfterShare?: string;
 }
 

--- a/src/external-services/linkedin/linkedin.service.ts
+++ b/src/external-services/linkedin/linkedin.service.ts
@@ -1,0 +1,183 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import axios from 'axios';
+import { UserProfilesService } from 'src/user-profiles/user-profiles.service';
+import { UsersService } from 'src/users/users.service';
+
+const LINKEDIN_API_URL = 'https://api.linkedin.com';
+const LINKEDIN_AUTH_URL = 'https://www.linkedin.com/oauth/v2/authorization';
+const LINKEDIN_TOKEN_URL = 'https://www.linkedin.com/oauth/v2/accessToken';
+const LINKEDIN_USERINFO_URL = `${LINKEDIN_API_URL}/v2/userinfo`;
+const LINKEDIN_POSTS_URL = `${LINKEDIN_API_URL}/rest/posts`;
+const LINKEDIN_API_VERSION = '202604';
+
+export interface LinkedInOAuthState {
+  userId?: string;
+  redirectAfterShare?: string;
+}
+
+export interface LinkedInTokenData {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresAt: Date;
+  linkedinId: string;
+}
+
+@Injectable()
+export class LinkedInService {
+  private readonly logger = new Logger(LinkedInService.name);
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly userProfilesService: UserProfilesService
+  ) {}
+
+  buildOAuthUrl(state: string): string {
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: process.env.LINKEDIN_CLIENT_ID,
+      redirect_uri: process.env.LINKEDIN_REDIRECT_URI,
+      scope: 'openid profile w_member_social',
+      state,
+    });
+    return `${LINKEDIN_AUTH_URL}?${params.toString()}`;
+  }
+
+  encodeState(data: LinkedInOAuthState): string {
+    return Buffer.from(JSON.stringify(data)).toString('base64');
+  }
+
+  decodeState(state: string): LinkedInOAuthState {
+    try {
+      return JSON.parse(Buffer.from(state, 'base64').toString('utf-8'));
+    } catch {
+      return {};
+    }
+  }
+
+  async exchangeCodeForToken(code: string): Promise<LinkedInTokenData> {
+    const params = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: process.env.LINKEDIN_REDIRECT_URI,
+      client_id: process.env.LINKEDIN_CLIENT_ID,
+      client_secret: process.env.LINKEDIN_CLIENT_SECRET,
+    });
+
+    const tokenResponse = await axios.post(LINKEDIN_TOKEN_URL, params, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+
+    const { access_token, refresh_token, expires_in } = tokenResponse.data;
+
+    const userinfoResponse = await axios.get(LINKEDIN_USERINFO_URL, {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+
+    const linkedinId: string = userinfoResponse.data.sub;
+    const expiresAt = new Date(Date.now() + expires_in * 1000);
+
+    return {
+      accessToken: access_token,
+      refreshToken: refresh_token ?? null,
+      expiresAt,
+      linkedinId,
+    };
+  }
+
+  async storeToken(
+    userId: string,
+    tokenData: LinkedInTokenData
+  ): Promise<void> {
+    await this.usersService.update(userId, {
+      linkedinId: tokenData.linkedinId,
+      linkedinAccessToken: tokenData.accessToken,
+      linkedinRefreshToken: tokenData.refreshToken,
+      linkedinTokenExpiresAt: tokenData.expiresAt,
+    });
+  }
+
+  async unlinkAccount(userId: string): Promise<void> {
+    await this.usersService.update(userId, {
+      linkedinId: null,
+      linkedinAccessToken: null,
+      linkedinRefreshToken: null,
+      linkedinTokenExpiresAt: null,
+    });
+  }
+
+  async shareProfile(
+    sharingUserId: string,
+    profileUserId: string
+  ): Promise<void> {
+    const user = await this.usersService.findOneWithAttributes(sharingUserId, [
+      'id',
+      'linkedinId',
+      'linkedinAccessToken',
+      'linkedinTokenExpiresAt',
+    ]);
+
+    if (!user?.linkedinAccessToken) {
+      throw new UnauthorizedException('LinkedIn account not linked');
+    }
+
+    if (
+      user.linkedinTokenExpiresAt &&
+      new Date(user.linkedinTokenExpiresAt) < new Date()
+    ) {
+      throw new UnauthorizedException(
+        'LinkedIn token expired, please relink your account'
+      );
+    }
+
+    const profileUrl = `${process.env.FRONT_URL}/cv/${profileUserId}`;
+    const commentary = await this.userProfilesService.getShareText(
+      profileUserId,
+      'linkedin'
+    );
+    try {
+      await axios.post(
+        LINKEDIN_POSTS_URL,
+        {
+          author: `urn:li:person:${user.linkedinId}`,
+          commentary,
+          visibility: 'PUBLIC',
+          distribution: {
+            feedDistribution: 'MAIN_FEED',
+            targetEntities: [],
+            thirdPartyDistributionChannels: [],
+          },
+          ...(profileUrl.startsWith('http://localhost')
+            ? {}
+            : {
+                content: {
+                  article: {
+                    source: profileUrl,
+                    title: `Entourage Pro - Aidez ce candidat a retrouver un emploi`,
+                    description: `Decouvrez le profil et donnez-lui un coup de pouce !`,
+                  },
+                },
+              }),
+          lifecycleState: 'PUBLISHED',
+          isReshareDisabledByAuthor: false,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${user.linkedinAccessToken}`,
+            'LinkedIn-Version': LINKEDIN_API_VERSION,
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to share profile on LinkedIn for user ${sharingUserId} and profile ${profileUserId}`,
+        error instanceof Error ? error.stack : JSON.stringify(error)
+      );
+      throw new BadRequestException('Failed to share profile on LinkedIn');
+    }
+  }
+}

--- a/src/user-profiles/user-profiles.controller.ts
+++ b/src/user-profiles/user-profiles.controller.ts
@@ -354,6 +354,12 @@ export class UserProfilesController {
     );
   }
 
+  @Get('/:userId/share-text')
+  async getShareText(@Param('userId', new ParseUUIDPipe()) userId: string) {
+    const text = await this.userProfilesService.getShareText(userId);
+    return { text };
+  }
+
   @Get('/:userId')
   async findByUserId(
     @Param('userId', new ParseUUIDPipe()) userIdToGet: string

--- a/src/user-profiles/user-profiles.service.ts
+++ b/src/user-profiles/user-profiles.service.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import {
-  BadRequestException,
   forwardRef,
   Inject,
   Injectable,
+  NotFoundException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import sequelize, { Op, WhereOptions, QueryTypes } from 'sequelize';
@@ -1527,7 +1527,7 @@ export class UserProfilesService {
     const userProfile = await this.findOneByUserId(profileUserId, true);
 
     if (!userProfile) {
-      throw new BadRequestException('Candidate profile not found');
+      throw new NotFoundException('Candidate profile not found');
     }
 
     const candidateUser = await this.usersService.findOneWithAttributes(

--- a/src/user-profiles/user-profiles.service.ts
+++ b/src/user-profiles/user-profiles.service.ts
@@ -1572,7 +1572,7 @@ export class UserProfilesService {
 
     const posteRecherche = profile.currentJob
       ? stripParens(profile.currentJob)
-      : 'un poste';
+      : null;
 
     const skills = (profile.skills ?? [])
       .map((s) => stripParens(s.name))
@@ -1594,7 +1594,11 @@ export class UserProfilesService {
           ? '@[Entourage](urn:li:organization:9177905)'
           : 'Entourage'
       } qui redonne un réseau pro à ceux qui n'en ont pas.\n\n` +
-      `${prenom} est basé à ${ville}, à la recherche d'un ${typeContrat}${secteurLine} Son objectif : décrocher un poste de ${posteRecherche}.${skillsLine}\n\n` +
+      `${prenom} est basé à ${ville}, à la recherche d'un ${typeContrat}${secteurLine} Son objectif : ${
+        posteRecherche
+          ? `décrocher un poste de ${posteRecherche}`
+          : 'décrocher un emploi'
+      }.${skillsLine}\n\n` +
       `Il a tout pour réussir. Ce qui lui manque, c'est du réseau. Si vous connaissez quelqu'un qui recrute, qui travaille dans ce secteur, ou si vous avez simplement 10 minutes pour un échange — votre coup de pouce peut changer la donne.\n\n` +
       `Son profil complet est ici : ${profileUrl}\n\n` +
       `N'hésitez pas à me contacter ou à contacter ${prenom} directement. Merci d'avance.`

--- a/src/user-profiles/user-profiles.service.ts
+++ b/src/user-profiles/user-profiles.service.ts
@@ -1,5 +1,10 @@
 import fs from 'fs';
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  forwardRef,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import sequelize, { Op, WhereOptions, QueryTypes } from 'sequelize';
 import sharp from 'sharp';
@@ -67,6 +72,8 @@ import { SCORING_WEIGHTS } from './recommendations/scoring.config';
 import { UserProfileRecommendationsService } from './recommendations/user-profile-recommendations-ai.service';
 import { ContactTypeEnum } from './user-profiles.types';
 import { userProfileSearchQuery } from './user-profiles.utils';
+
+const LINKEDIN_ENTOURAGE_PRO_ORG_ID = '42693016';
 
 @Injectable()
 export class UserProfilesService {
@@ -1510,6 +1517,87 @@ export class UserProfilesService {
         userId,
         embeddingTypes: embeddingTypesToUpdate,
       }
+    );
+  }
+
+  async getShareText(
+    profileUserId: string,
+    channel: 'linkedin' | 'default' = 'default'
+  ): Promise<string> {
+    const userProfile = await this.findOneByUserId(profileUserId, true);
+
+    if (!userProfile) {
+      throw new BadRequestException('Candidate profile not found');
+    }
+
+    const candidateUser = await this.usersService.findOneWithAttributes(
+      profileUserId,
+      ['id', 'firstName']
+    );
+
+    const profileUrl = `${process.env.FRONT_URL}/cv/${profileUserId}`;
+    return this.generateShareText(
+      userProfile,
+      candidateUser?.firstName ?? '',
+      profileUrl,
+      channel
+    );
+  }
+
+  generateShareText(
+    profile: UserProfile,
+    firstName: string,
+    profileUrl: string,
+    channel: 'linkedin' | 'default' = 'default'
+  ): string {
+    const stripParens = (s: string) => s.replace(/\s*\([^)]*\)/g, '').trim();
+
+    const prenom = firstName || 'ce candidat';
+    const ville = stripParens(profile.department || 'sa région');
+
+    const contracts = (profile.contracts ?? [])
+      .map((c) => stripParens(c.name))
+      .filter(Boolean);
+    const typeContrat = contracts[0] || 'un emploi';
+
+    const sectorNames = (profile.sectorOccupations ?? [])
+      .map((s) =>
+        stripParens(s.occupation?.name ?? s.businessSector?.name ?? '')
+      )
+      .filter(Boolean);
+    const secteurLine =
+      sectorNames.length > 0
+        ? ` dans les domaines ${sectorNames.slice(0, 2).join(' et ')}.`
+        : '.';
+
+    const posteRecherche = profile.currentJob
+      ? stripParens(profile.currentJob)
+      : 'un poste';
+
+    const skills = (profile.skills ?? [])
+      .map((s) => stripParens(s.name))
+      .filter(Boolean);
+    const skillsLine =
+      skills.length > 0
+        ? `\n\nCe qu'il apporte : ${skills
+            .slice(0, 3)
+            .join(', ')} — et bien plus encore.`
+        : '';
+
+    return (
+      `Je soutiens ${prenom} dans sa recherche professionnelle via ${
+        channel === 'linkedin'
+          ? `@[Entourage Pro](urn:li:organization:${LINKEDIN_ENTOURAGE_PRO_ORG_ID})`
+          : 'Entourage Pro'
+      } — un programme de l'association ${
+        channel === 'linkedin'
+          ? '@[Entourage](urn:li:organization:9177905)'
+          : 'Entourage'
+      } qui redonne un réseau pro à ceux qui n'en ont pas.\n\n` +
+      `${prenom} est basé à ${ville}, à la recherche d'un ${typeContrat}${secteurLine} Son objectif : décrocher un poste de ${posteRecherche}.${skillsLine}\n\n` +
+      `Il a tout pour réussir. Ce qui lui manque, c'est du réseau. Si vous connaissez quelqu'un qui recrute, qui travaille dans ce secteur, ou si vous avez simplement 10 minutes pour un échange — votre coup de pouce peut changer la donne.\n\n` +
+      `Son profil complet est ici : ${profileUrl}\n\n` +
+      `N'hésitez pas à me contacter ou à contacter ${prenom} directement. Merci d'avance.`
     );
   }
 }

--- a/src/users/models/user.model.ts
+++ b/src/users/models/user.model.ts
@@ -186,6 +186,22 @@ export class User extends HistorizedModel {
   @Column
   onboardingWebinarSkippedAt: Date;
 
+  @AllowNull(true)
+  @Column
+  linkedinId: string;
+
+  @AllowNull(true)
+  @Column(DataType.TEXT)
+  linkedinAccessToken: string;
+
+  @AllowNull(true)
+  @Column(DataType.TEXT)
+  linkedinRefreshToken: string;
+
+  @AllowNull(true)
+  @Column
+  linkedinTokenExpiresAt: Date;
+
   @CreatedAt
   createdAt: Date;
 

--- a/src/users/models/user.model.ts
+++ b/src/users/models/user.model.ts
@@ -336,8 +336,16 @@ export class User extends HistorizedModel {
 
   toJSON() {
     const attributes = this.get({ plain: true });
-    // Remove companies and add company
-    const { companies, ...rest } = attributes;
+    const {
+      companies,
+      password,
+      salt,
+      hashReset,
+      saltReset,
+      linkedinAccessToken,
+      linkedinRefreshToken,
+      ...rest
+    } = attributes;
     return {
       ...rest,
       company:

--- a/tests/users/user.factory.ts
+++ b/tests/users/user.factory.ts
@@ -91,7 +91,7 @@ export class UserFactory implements Factory<User> {
     }
     const builtUser = await this.userModel.build(userData);
     const { id, isEmailVerified, ...builtUserWithoutIdAndIsEmailVerified } =
-      builtUser.toJSON();
+      builtUser.get({ plain: true });
     return builtUserWithoutIdAndIsEmailVerified as User;
   }
 


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9097](https://entourage-asso.atlassian.net/browse/EN-9097) [EN-9098](https://entourage-asso.atlassian.net/browse/EN-9098) [EN-9101](https://entourage-asso.atlassian.net/browse/EN-9101)
**🚧 PR-Front :** [front/693](https://github.com/ReseauEntourage/entourage-job-front/pull/693)
**💬 Commentaire :**

This pull request introduces LinkedIn OAuth integration, enabling users to link their LinkedIn accounts and share candidate profiles directly to LinkedIn. It adds the necessary backend infrastructure for OAuth, token management, and profile sharing, as well as updates to the user model and API endpoints to support these features.

**LinkedIn OAuth Integration:**

* Adds LinkedIn OAuth configuration to `.env.dist` for client ID, secret, and redirect URI.
* Introduces a new migration to add `linkedinId`, `linkedinAccessToken`, `linkedinRefreshToken`, and `linkedinTokenExpiresAt` fields to the `Users` table.
* Updates the `User` model to include new LinkedIn-related fields.

**API and Service Layer:**

* Implements the `LinkedInModule` with a controller and service to handle OAuth flow (authorization URL, token exchange, unlinking account) and profile sharing to LinkedIn. [[1]](diffhunk://#diff-0f99136fb41c5c311da9ca85c63678ac79f570457b5826df381898e050ddd70bR1-R16) [[2]](diffhunk://#diff-d34916ad62c32eab46082bf5c8f90ca2f840532ec1d4b8acd2d7dd1faa626803R1-R79) [[3]](diffhunk://#diff-40bf3261badc43ef41853234be67cfbc9760e0b7747aa54ae017959a5885aa24R1-R183)
* Registers the new module in `app.module.ts` to make LinkedIn features available in the application. [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R33) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R150)

**User Profile Sharing:**

* Adds a method to `UserProfilesService` to generate shareable text for candidate profiles, tailored for LinkedIn or default channels, and exposes an endpoint for retrieving this text. [[1]](diffhunk://#diff-68a3f696de85f42a907de2fdfb124fc1cf7b5460e867943e1bc7f00f30ba4648R76-R77) [[2]](diffhunk://#diff-68a3f696de85f42a907de2fdfb124fc1cf7b5460e867943e1bc7f00f30ba4648R1522-R1602) [[3]](diffhunk://#diff-c7afca6ec9640e03f8b854185415abded89e522c22f4aa273686ef2c6d05448cR357-R362)

**User Identity and DTO Updates:**

* Updates the current user identity DTO to include a `hasLinkedinLinked` property, and ensures the LinkedIn access token is handled securely (fetched but not exposed). [[1]](diffhunk://#diff-8d373c6d3e8acb959a62e1feff04b6fe08591d6c2096f05019955d15a3b02a85R23-R30) [[2]](diffhunk://#diff-8d373c6d3e8acb959a62e1feff04b6fe08591d6c2096f05019955d15a3b02a85R46) [[3]](diffhunk://#diff-8d373c6d3e8acb959a62e1feff04b6fe08591d6c2096f05019955d15a3b02a85R70)

[EN-9097]: https://entourage-asso.atlassian.net/browse/EN-9097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-9098]: https://entourage-asso.atlassian.net/browse/EN-9098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-9101]: https://entourage-asso.atlassian.net/browse/EN-9101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ