### PR TITLE
Update DAYS_TO_CONTACT to include 2 and 10 days in unread mails

### DIFF
--- a/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
+++ b/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
@@ -1173,7 +1173,7 @@ export class CronTasksProcessor extends WorkerHost {
   }
 
   async prepareUnreadConversationsMails() {
-    const DAYS_TO_CONTACT = [4, 20];
+    const DAYS_TO_CONTACT = [2, 10, 20];
     this.logger.log(
       `Preparing unread conversations mails for days ${DAYS_TO_CONTACT.join(
         ', '


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9209](https://entourage-asso.atlassian.net/browse/EN-9209)
**💬 Commentaire :**

This pull request updates the configuration for preparing unread conversation reminder emails in the `CronTasksProcessor`. The main change is to adjust the timing of when users are contacted about unread conversations.

Notification schedule update:

* Updated the `DAYS_TO_CONTACT` array in `prepareUnreadConversationsMails` to send reminder emails at 2, 10, and 20 days (previously 4 and 20 days), making the notifications more frequent and timely.

[EN-9209]: https://entourage-asso.atlassian.net/browse/EN-9209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ