### PR TITLE
Add LinkedIn profile sharing email feature for coaches

### DIFF
--- a/src/cron/cron.service.ts
+++ b/src/cron/cron.service.ts
@@ -136,6 +136,24 @@ export class CronService {
     };
   }
 
+  @Cron(CronExpression.EVERY_DAY_AT_10AM)
+  async prepareLinkedInShareProfileMails() {
+    this.logger.log('Cron job started: prepareLinkedInShareProfileMails');
+    const job = await this.queuesService.addToCronTasksQueue(
+      Jobs.PREPARE_LINKEDIN_SHARE_PROFILE_MAILS,
+      {}
+    );
+
+    this.logger.log(
+      `Job PREPARE_LINKEDIN_SHARE_PROFILE_MAILS created (Job ID: ${job.id})`
+    );
+
+    return {
+      jobId: job.id,
+      status: 'processing',
+    };
+  }
+
   @Cron(CronExpression.EVERY_DAY_AT_2AM)
   async prepareAutoSetUnavailableUsers() {
     this.logger.log('Cron job started: prepareAutoSetUnavailableUsers');

--- a/src/external-services/mailjet/mailjet.types.ts
+++ b/src/external-services/mailjet/mailjet.types.ts
@@ -154,6 +154,7 @@ export const MailjetTemplates = {
   MAILER_INACTIVE_REFERERS: 6639639,
   MAILER_MESSAGING_FEEDBACK: 6811416,
   MAILER_WARN_ACCOUNT_DELETION: 6611907,
+  MAILER_LINKEDIN_SHARE_PROFILE: 8052814,
 } as const;
 
 export type MailjetTemplateKey = keyof typeof MailjetTemplates;

--- a/src/mails/mails.service.ts
+++ b/src/mails/mails.service.ts
@@ -588,6 +588,23 @@ export class MailsService {
     });
   }
 
+  async sendLinkedInShareProfileMail(coach: User, candidate: User) {
+    this.logger.log(
+      `Sending LinkedIn share profile mail to coach ${coach.email} for candidate ${candidate.id}`
+    );
+    return await this.queuesService.addToWorkQueue(Jobs.SEND_MAIL, {
+      toEmail: coach.email,
+      replyTo: coach.staffContact.email,
+      templateId: MailjetTemplates.MAILER_LINKEDIN_SHARE_PROFILE,
+      variables: {
+        firstName: coach.firstName,
+        interlocutorFirstName: candidate.firstName,
+        ctaUrl: `${process.env.FRONT_URL}/backoffice/profile/${candidate.id}`,
+        staffContact: coach.staffContact,
+      },
+    });
+  }
+
   async sendFollowUpMailForMutuallyRepliedConversation(
     user: User,
     conversation: Conversation

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -1114,6 +1114,75 @@ export class MessagingService {
     });
   }
 
+  async getConversationsReadyForLinkedInShareMail(
+    daysSinceThirdMessage: number
+  ) {
+    const conversations: { id: string }[] =
+      await this.conversationModel.sequelize.query(
+        `
+        SELECT c."id"
+        FROM "Conversations" c
+        WHERE
+          -- The 3rd message was sent exactly :days days ago
+          (
+            SELECT m."createdAt"
+            FROM "Messages" m
+            WHERE m."conversationId" = c."id"
+            ORDER BY m."createdAt" ASC
+            OFFSET 2 LIMIT 1
+          ) BETWEEN
+            (NOW() - make_interval(days => :daysPlusOne))
+            AND (NOW() - make_interval(days => :days))
+          AND (
+            SELECT COUNT(*)
+            FROM "ConversationParticipants" cp
+            JOIN "Users" u ON u."id" = cp."userId" AND u."deletedAt" IS NULL
+            WHERE cp."conversationId" = c."id"
+              AND u.role IN (:coachRole, :candidateRole)
+          ) = 2
+          AND (
+            SELECT COUNT(*)
+            FROM "ConversationParticipants" cp
+            JOIN "Users" u ON u."id" = cp."userId" AND u."deletedAt" IS NULL
+            WHERE cp."conversationId" = c."id"
+              AND u.role = :coachRole
+          ) = 1
+          AND NOT EXISTS (
+            SELECT 1
+            FROM "ConversationParticipants" cp_all
+            WHERE cp_all."conversationId" = c."id"
+            AND NOT EXISTS (
+              SELECT 1
+              FROM "Messages" m
+              WHERE m."conversationId" = c."id"
+                AND m."authorId" = cp_all."userId"
+            )
+          )
+        `,
+        {
+          type: QueryTypes.SELECT,
+          replacements: {
+            days: daysSinceThirdMessage,
+            daysPlusOne: daysSinceThirdMessage + 1,
+            coachRole: UserRoles.COACH,
+            candidateRole: UserRoles.CANDIDATE,
+          },
+        }
+      );
+
+    const conversationIds = conversations.map((c) => c.id);
+    return this.conversationModel.findAll({
+      where: { id: { [Op.in]: conversationIds } },
+      include: [
+        {
+          model: User,
+          attributes: userAttributes,
+          as: 'participants',
+        },
+      ],
+    });
+  }
+
   /**
    * Get IDs of users who are still available but haven't logged in for at least
    * `daysWithoutConnection` days AND have at least one unread conversation message

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -1171,9 +1171,11 @@ export class MessagingService {
       );
 
     const conversationIds = conversations.map((c) => c.id);
+    if (conversationIds.length === 0) {
+      return [];
+    }
     return this.conversationModel.findAll({
       where: { id: { [Op.in]: conversationIds } },
-      include: [
         {
           model: User,
           attributes: userAttributes,

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -1123,16 +1123,14 @@ export class MessagingService {
         SELECT c."id"
         FROM "Conversations" c
         WHERE
-          -- The 3rd message was sent exactly :days days ago
+          -- The 3rd message was sent on the calendar day exactly :days days ago
           (
-            SELECT m."createdAt"
+            SELECT m."createdAt"::date
             FROM "Messages" m
             WHERE m."conversationId" = c."id"
             ORDER BY m."createdAt" ASC
             OFFSET 2 LIMIT 1
-          ) BETWEEN
-            (NOW() - make_interval(days => :daysPlusOne))
-            AND (NOW() - make_interval(days => :days))
+          ) = CURRENT_DATE - make_interval(days => :days)
           AND (
             SELECT COUNT(*)
             FROM "ConversationParticipants" cp
@@ -1150,6 +1148,9 @@ export class MessagingService {
           AND NOT EXISTS (
             SELECT 1
             FROM "ConversationParticipants" cp_all
+            JOIN "Users" u_all ON u_all."id" = cp_all."userId"
+              AND u_all."deletedAt" IS NULL
+              AND u_all.role IN (:coachRole, :candidateRole)
             WHERE cp_all."conversationId" = c."id"
             AND NOT EXISTS (
               SELECT 1
@@ -1163,7 +1164,6 @@ export class MessagingService {
           type: QueryTypes.SELECT,
           replacements: {
             days: daysSinceThirdMessage,
-            daysPlusOne: daysSinceThirdMessage + 1,
             coachRole: UserRoles.COACH,
             candidateRole: UserRoles.CANDIDATE,
           },
@@ -1176,6 +1176,7 @@ export class MessagingService {
     }
     return this.conversationModel.findAll({
       where: { id: { [Op.in]: conversationIds } },
+      include: [
         {
           model: User,
           attributes: userAttributes,

--- a/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
+++ b/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
@@ -15,6 +15,7 @@ import { UserProfileRecommendationsService } from 'src/user-profiles/recommendat
 import { UserProfilesService } from 'src/user-profiles/user-profiles.service';
 import { User } from 'src/users/models';
 import { UsersService } from 'src/users/users.service';
+import { UserRoles } from 'src/users/users.types';
 import { UsersDeletionService } from 'src/users-deletion/users-deletion.service';
 import { getZoneNameFromDepartment } from 'src/utils/misc';
 
@@ -89,6 +90,8 @@ export class CronTasksProcessor extends WorkerHost {
         return this.prepareWarnAccountDeletionMails();
       case Jobs.PREPARE_UNANSWERED_CONVERSATIONS_SMS:
         return this.prepareUnansweredConversationsSms();
+      case Jobs.PREPARE_LINKEDIN_SHARE_PROFILE_MAILS:
+        return this.prepareLinkedInShareProfileMails();
       default:
         this.logger.error(
           `No process method for job ${job.id} with name ${job.name}`
@@ -1551,5 +1554,92 @@ export class CronTasksProcessor extends WorkerHost {
     }
 
     return `Sent ${successIds.length} unanswered conversation SMS`;
+  }
+
+  private async prepareLinkedInShareProfileMails() {
+    const DAYS_SINCE_CONVERSATION_START = 7;
+    this.logger.log(
+      `Preparing LinkedIn share profile mails for coaches whose conversation reached 3 messages ${DAYS_SINCE_CONVERSATION_START} days ago...`
+    );
+
+    const conversations =
+      await this.messagingService.getConversationsReadyForLinkedInShareMail(
+        DAYS_SINCE_CONVERSATION_START
+      );
+
+    this.logger.log(
+      `Found ${conversations.length} conversations eligible for LinkedIn share profile mail`
+    );
+
+    const mailJobs = conversations.flatMap((conversation) => {
+      const coach = conversation.participants.find(
+        (p) => p.role === UserRoles.COACH
+      );
+      const candidate = conversation.participants.find(
+        (p) => p.role === UserRoles.CANDIDATE
+      );
+      if (!coach || !candidate) return [];
+      return [{ id: `${conversation.id}:${coach.id}`, coach, candidate }];
+    });
+
+    const participantIds = Array.from(
+      new Set(mailJobs.flatMap((j) => [j.coach.id, j.candidate.id]))
+    );
+    const participantsWithRelations =
+      participantIds.length > 0
+        ? await this.usersService.findByIdsWithRelations(participantIds)
+        : [];
+    const participantsById = new Map<string, User>(
+      participantsWithRelations.map((u) => [u.id, u])
+    );
+
+    const hydratedJobs = mailJobs.map((j) => ({
+      ...j,
+      coach: participantsById.get(j.coach.id) ?? j.coach,
+      candidate: participantsById.get(j.candidate.id) ?? j.candidate,
+    }));
+
+    const results = await Promise.allSettled(
+      hydratedJobs.map(async (job) => {
+        this.logger.log(
+          `Preparing LinkedIn share profile mail for coach ${job.coach.id} with candidate ${job.candidate.id}`
+        );
+        return await this.usersService.sendLinkedInShareProfileMail(
+          job.coach,
+          job.candidate
+        );
+      })
+    );
+
+    const { succeeded, successIds, failures } = collectSettledResults(
+      hydratedJobs,
+      results,
+      (jobId, reason) => {
+        const [conversationId, coachId] = String(jobId).split(':');
+        this.logger.error(
+          `Failed preparing LinkedIn share profile mail for coach ${coachId} (conversation ${conversationId})`,
+          reason
+        );
+      }
+    );
+
+    await this.cronTasksSlackReporterService.sendCronTaskResultToSlack(
+      succeeded,
+      `🔗 LinkedIn share profile - J+${DAYS_SINCE_CONVERSATION_START}`,
+      {
+        total: hydratedJobs.length,
+        success: successIds.length,
+        failure: failures.length,
+      },
+      failures
+    );
+
+    if (!succeeded) {
+      this.logger.error(
+        `Failed preparing LinkedIn share profile mails for ${failures.length}/${hydratedJobs.length} coaches`
+      );
+    }
+
+    return `Preparation of LinkedIn share profile mails for ${hydratedJobs.length} coaches started.`;
   }
 }

--- a/src/queues/queues.types.ts
+++ b/src/queues/queues.types.ts
@@ -67,6 +67,7 @@ export const Jobs = {
   PREPARE_MESSAGING_FEEDBACK_MAILS: 'prepare_messaging_feedback_mails',
   PREPARE_WARN_ACCOUNT_DELETION_MAILS: 'prepare_warn_account_deletion_mails',
   PREPARE_UNANSWERED_CONVERSATIONS_SMS: 'prepare_unanswered_conversations_sms',
+  PREPARE_LINKEDIN_SHARE_PROFILE_MAILS: 'prepare_linkedin_share_profile_mails',
 
   // Jobs related to embedding queue
   UPDATE_USER_PROFILE_EMBEDDINGS: 'update_user_profile_embeddings',
@@ -117,6 +118,7 @@ type JobsData = {
   [Jobs.PREPARE_MESSAGING_FEEDBACK_MAILS]: PrepareMessagingFeedbackMailsJob;
   [Jobs.PREPARE_WARN_ACCOUNT_DELETION_MAILS]: PrepareWarnAccountDeletionMailsJob;
   [Jobs.PREPARE_UNANSWERED_CONVERSATIONS_SMS]: PrepareUnansweredConversationsSmsJob;
+  [Jobs.PREPARE_LINKEDIN_SHARE_PROFILE_MAILS]: PrepareLinkedInShareProfileMailsJob;
 
   // Embedding queue jobs
   [Jobs.UPDATE_USER_PROFILE_EMBEDDINGS]: UpdateUserProfileEmbeddingsJob;
@@ -246,6 +248,8 @@ export interface PrepareMessagingFeedbackMailsJob {}
 export interface PrepareWarnAccountDeletionMailsJob {}
 
 export interface PrepareUnansweredConversationsSmsJob {}
+
+export interface PrepareLinkedInShareProfileMailsJob {}
 
 export interface UpdateUserProfileEmbeddingsJob {
   userId: string;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -969,6 +969,10 @@ export class UsersService {
     );
   }
 
+  async sendLinkedInShareProfileMail(coach: User, candidate: User) {
+    return this.mailsService.sendLinkedInShareProfileMail(coach, candidate);
+  }
+
   /**
    * Returns all non-deleted users who have connected to the platform
    * within the last `months` months, excluding Admins.


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9206](https://entourage-asso.atlassian.net/browse/EN-9206)
**💬 Commentaire :**

This pull request introduces a new automated workflow to send LinkedIn share profile emails to coaches whose conversations with candidates have reached a certain milestone. The workflow includes a daily cron job, supporting queue jobs, database queries to find eligible conversations, and the email-sending logic. The changes are primarily grouped into the new cron job infrastructure, queue/job definitions, messaging logic, and email template integration.

**Cron Job & Queue Infrastructure:**

- Added a new daily cron job (`prepareLinkedInShareProfileMails`) in `CronService` to enqueue the process of preparing LinkedIn share profile emails for eligible coaches.
- Defined a new queue job type (`PREPARE_LINKEDIN_SHARE_PROFILE_MAILS`) and its associated data interface in the queue types, and updated the jobs dispatcher and processor to handle this job. [[1]](diffhunk://#diff-ee8906796eb8b13aa925c36b66cbed2820293546896af3a6f02656cad1e420aaR70) [[2]](diffhunk://#diff-ee8906796eb8b13aa925c36b66cbed2820293546896af3a6f02656cad1e420aaR121) [[3]](diffhunk://#diff-ee8906796eb8b13aa925c36b66cbed2820293546896af3a6f02656cad1e420aaR252-R253) [[4]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7R93-R94)

**Eligibility & Processing Logic:**

- Implemented `getConversationsReadyForLinkedInShareMail` in `MessagingService`, which queries for conversations where the third message was sent exactly 7 days ago and both a coach and candidate are present and active.
- Added `prepareLinkedInShareProfileMails` method to the cron tasks processor, which finds eligible conversations, hydrates participant data, and triggers email jobs for each coach-candidate pair.

**Email Sending & Template Integration:**

- Added a new method `sendLinkedInShareProfileMail` in both `MailsService` and `UsersService` to send the LinkedIn share profile email using a new Mailjet template. [[1]](diffhunk://#diff-a897829bc6ed86b52d1a7336116247008ac1a0936ee9520feec464a6d063f94aR591-R607) [[2]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577R972-R975)
- Registered the new Mailjet template ID (`MAILER_LINKEDIN_SHARE_PROFILE`) for use with these emails.

**Other:**

- Imported `UserRoles` where needed to support role-based logic in participant selection.

[EN-9206]: https://entourage-asso.atlassian.net/browse/EN-9206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ