### PR TITLE
Add public audience type and filter for Salesforce events

### DIFF
--- a/src/events/dto/find-all-events-query.dto.ts
+++ b/src/events/dto/find-all-events-query.dto.ts
@@ -1,0 +1,71 @@
+import { Transform, Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { EventMode, EventPublicAudience, EventType } from '../event.types';
+
+const toArray = ({ value }: { value: unknown }) =>
+  Array.isArray(value) ? value : value !== undefined ? [value] : undefined;
+
+export class FindAllEventsQueryDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  @Type(() => Number)
+  limit?: number = 50;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  offset?: number = 0;
+
+  @IsOptional()
+  @IsBoolean()
+  @Type(() => Boolean)
+  includePastEvents?: boolean = false;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  search?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsEnum(EventMode, { each: true })
+  @Transform(toArray)
+  modes?: EventMode[];
+
+  @IsOptional()
+  @IsArray()
+  @IsEnum(EventType, { each: true })
+  @Transform(toArray)
+  eventTypes?: EventType[];
+
+  @IsOptional()
+  @IsArray()
+  @IsUUID(4, { each: true })
+  @Transform(toArray)
+  departmentIds?: string[];
+
+  @IsOptional()
+  @IsIn(['true', 'false'])
+  isParticipating?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsEnum(EventPublicAudience, { each: true })
+  @Transform(toArray)
+  publicSensibilise?: EventPublicAudience[];
+}

--- a/src/events/event.types.ts
+++ b/src/events/event.types.ts
@@ -17,6 +17,15 @@ export enum EventType {
   WORKSHOP = 'WORKSHOP',
 }
 
+export enum EventPublicAudience {
+  GENERAL_PUBLIC = 'Grand public',
+  COMPANIES = 'Entreprises',
+  ORGANIZATIONS = 'Associations',
+  SCHOLARS = 'Scolaire',
+  AUTHORITIES = 'Collectivité',
+  YOUNG_PUBLIC = 'Jeunes',
+}
+
 export enum SalesforceEventTypes {
   WELCOME_SESSION = 'Rdv de bienvenue Entourage Pro',
   COFFEE_SESSION = 'Info co candidat',
@@ -56,6 +65,7 @@ export interface Event {
   audience: string;
   sequences?: string[];
   isParticipating: boolean;
+  publicSensibilise: EventPublicAudience[] | null;
 }
 
 export type EventParticipant = Pick<

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -1,12 +1,9 @@
 import {
   Body,
   Controller,
-  DefaultValuePipe,
   Get,
   NotFoundException,
   Param,
-  ParseBoolPipe,
-  ParseIntPipe,
   Put,
   Query,
   ValidationPipe,
@@ -14,7 +11,7 @@ import {
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { UserPayload } from 'src/auth/guards';
 import { EventParticipationDto } from './dto/event-participation.dto';
-import { EventMode, EventPublicAudience, EventType } from './event.types';
+import { FindAllEventsQueryDto } from './dto/find-all-events-query.dto';
 import { EventsService } from './events.service';
 
 @ApiTags('Events')
@@ -26,29 +23,21 @@ export class EventsController {
   @Get()
   async findAll(
     @UserPayload('email') userEmail: string,
-    @Query('limit', new DefaultValuePipe(50), new ParseIntPipe())
-    limit: number,
-    @Query('offset', new DefaultValuePipe(0), new ParseIntPipe())
-    offset: number,
-    @Query(
-      'includePastEvents',
-      new DefaultValuePipe(false),
-      new ParseBoolPipe()
-    )
-    includePastEvents: boolean,
-    @Query('search')
-    search?: string,
-    @Query('modes')
-    modes?: EventMode[],
-    @Query('eventTypes')
-    eventTypes?: EventType[],
-    @Query('departmentIds')
-    departmentIds?: string[],
-    @Query('isParticipating')
-    isParticipating?: string,
-    @Query('publicSensibilise')
-    publicSensibilise?: EventPublicAudience[]
+    @Query(new ValidationPipe({ transform: true, whitelist: true }))
+    query: FindAllEventsQueryDto
   ) {
+    const {
+      limit,
+      offset,
+      includePastEvents,
+      isParticipating,
+      search,
+      modes,
+      eventTypes,
+      departmentIds,
+      publicSensibilise,
+    } = query;
+
     const events = await this.eventsService.findAllEvents(
       userEmail,
       limit,

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -45,7 +45,9 @@ export class EventsController {
     @Query('departmentIds')
     departmentIds?: string[],
     @Query('isParticipating')
-    isParticipating?: string
+    isParticipating?: string,
+    @Query('publicSensibilise')
+    publicSensibilise?: string[]
   ) {
     const events = await this.eventsService.findAllEvents(
       userEmail,
@@ -56,7 +58,8 @@ export class EventsController {
       search,
       modes,
       eventTypes,
-      departmentIds
+      departmentIds,
+      publicSensibilise
     );
 
     return events;

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -14,7 +14,7 @@ import {
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { UserPayload } from 'src/auth/guards';
 import { EventParticipationDto } from './dto/event-participation.dto';
-import { EventMode, EventType } from './event.types';
+import { EventMode, EventPublicAudience, EventType } from './event.types';
 import { EventsService } from './events.service';
 
 @ApiTags('Events')
@@ -47,7 +47,7 @@ export class EventsController {
     @Query('isParticipating')
     isParticipating?: string,
     @Query('publicSensibilise')
-    publicSensibilise?: string[]
+    publicSensibilise?: EventPublicAudience[]
   ) {
     const events = await this.eventsService.findAllEvents(
       userEmail,

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -9,6 +9,7 @@ import { SfLocalBranchName } from 'src/utils/types/local-branches.types';
 import {
   Event,
   EventMode,
+  EventPublicAudience,
   Events,
   EventType,
   EventWithParticipants,
@@ -41,7 +42,7 @@ export class EventsService {
     modes?: EventMode[],
     eventTypes?: EventType[],
     departmentIds?: string[],
-    publicSensibilise?: string[]
+    publicSensibilise?: EventPublicAudience[]
   ): Promise<Events> {
     const departmentNames =
       await this.departmentsService.mapDepartmentsIdsToFormattedNames(

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -40,7 +40,8 @@ export class EventsService {
     search = '',
     modes?: EventMode[],
     eventTypes?: EventType[],
-    departmentIds?: string[]
+    departmentIds?: string[],
+    publicSensibilise?: string[]
   ): Promise<Events> {
     const departmentNames =
       await this.departmentsService.mapDepartmentsIdsToFormattedNames(
@@ -66,7 +67,8 @@ export class EventsService {
       search,
       modes,
       eventTypes,
-      localBranches
+      localBranches,
+      publicSensibilise
     );
 
     return sfCampaigns

--- a/src/events/events.utils.ts
+++ b/src/events/events.utils.ts
@@ -3,6 +3,7 @@ import { SalesforceCampaign } from 'src/external-services/salesforce/salesforce.
 import {
   Event,
   EventMode,
+  EventPublicAudience,
   EventType,
   SalesforceEventTypes,
 } from './event.types';
@@ -25,6 +26,7 @@ export const salesforceEventAttributes = [
   'Nombre_de_participants__c',
   'Nombre_d_inscrits__c',
   'MeetingLink__c',
+  'Public_sensibilis__c',
 ];
 
 /**
@@ -253,6 +255,11 @@ export const convertSalesforceCampaignToEvent = (
     mode,
     duration: computeEventDurationFromSalesforceCampaign(campaign),
     isParticipating,
+    publicSensibilise: campaign.Public_sensibilis__c
+      ? (campaign.Public_sensibilis__c.split(';').map((v) =>
+          v.trim()
+        ) as EventPublicAudience[])
+      : null,
     ...additionalEventAttributesByEventType[eventType],
     ...(eventType === EventType.WORKSHOP && {
       format: mode === EventMode.ONLINE ? 'En ligne' : 'En présentiel',

--- a/src/external-services/salesforce/salesforce.service.ts
+++ b/src/external-services/salesforce/salesforce.service.ts
@@ -14,7 +14,11 @@ import {
   WorkingExperience,
   YesNoJNSPRValue,
 } from 'src/contacts/contacts.types';
-import { EventMode, EventType } from 'src/events/event.types';
+import {
+  EventMode,
+  EventPublicAudience,
+  EventType,
+} from 'src/events/event.types';
 import {
   eventTypeToSalesforceEventType,
   salesforceEventAttributes,
@@ -423,7 +427,7 @@ export class SalesforceService {
     modes?: EventMode[],
     eventTypes?: EventType[],
     localBranches?: SfLocalBranchName[],
-    publicSensibilise?: string[]
+    publicSensibilise?: EventPublicAudience[]
   ) {
     await this.checkIfConnected();
 

--- a/src/external-services/salesforce/salesforce.service.ts
+++ b/src/external-services/salesforce/salesforce.service.ts
@@ -422,7 +422,8 @@ export class SalesforceService {
     search = '',
     modes?: EventMode[],
     eventTypes?: EventType[],
-    localBranches?: SfLocalBranchName[]
+    localBranches?: SfLocalBranchName[],
+    publicSensibilise?: string[]
   ) {
     await this.checkIfConnected();
 
@@ -483,6 +484,13 @@ export class SalesforceService {
             `
         : '';
 
+    const publicSensibiliseFilter =
+      publicSensibilise && publicSensibilise.length > 0
+        ? `AND Public_sensibilis__c INCLUDES (${publicSensibilise
+            .map((v) => `'${escapeQuery(v)}'`)
+            .join(', ')})`
+        : '';
+
     let isParticipatingCondition = '';
     if (contactId && isParticipating === true) {
       isParticipatingCondition = `
@@ -522,6 +530,7 @@ export class SalesforceService {
             ${modeFilters}
             ${eventTypesFilters}
             ${localBranchesCondition}
+            ${publicSensibiliseFilter}
             ${isParticipatingCondition}
             ${pastEventsCondition}
             ORDER BY StartDate ASC, Heure_d_but__c ASC

--- a/src/external-services/salesforce/salesforce.types.ts
+++ b/src/external-services/salesforce/salesforce.types.ts
@@ -393,6 +393,7 @@ export interface SalesforceCampaign {
   CampaignMembers?: {
     records: Partial<SalesforceCampaignMember>[];
   };
+  Public_sensibilis__c?: string;
 }
 
 export enum SalesforceCampaignStatus {


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9216](https://entourage-asso.atlassian.net/browse/EN-9216) [EN-9217](https://entourage-asso.atlassian.net/browse/EN-9217) [EN-9218](https://entourage-asso.atlassian.net/browse/EN-9218)
**🚧 PR-Front :** [front/702](https://github.com/ReseauEntourage/entourage-job-front/pull/702)
**💬 Commentaire :**

This pull request adds support for filtering and exposing the "public sensibilisé" (target audience) of events throughout the backend. It introduces a new `EventPublicAudience` enum, updates the event model, and extends the API and Salesforce integration to handle this new field, allowing clients to filter events by their public audience.

**Event audience support and filtering:**

* Introduced the `EventPublicAudience` enum in `event.types.ts` to represent possible public audiences for events, such as "Grand public", "Entreprises", etc.
* Added a `publicSensibilise` field to the `Event` interface to store the audiences targeted by each event, and updated the Salesforce campaign conversion logic to populate this field from the `Public_sensibilis__c` Salesforce attribute. [[1]](diffhunk://#diff-4e3b5ba45d67cab48a26893c6bb8db7713c1aee8519f43df7b6d3fdc442a25beR68) [[2]](diffhunk://#diff-d902b8623fa9e8780ea03a3b88cfcff53593d1cd2076588a33f02f09cb44c50bR258-R262) [[3]](diffhunk://#diff-1d140d9a0f44bcceb90f283565045ef72068877ddb4f17dfd95129de0863a525R396)

**API and service enhancements:**

* Updated the events API (`EventsController` and `EventsService`) to accept a `publicSensibilise` query parameter for filtering events by audience. [[1]](diffhunk://#diff-8e9ad5e94f0c0f0eb806c0d747cd15cee3968b89b89a95d8e21381a46ad8dee2L48-R50) [[2]](diffhunk://#diff-8e9ad5e94f0c0f0eb806c0d747cd15cee3968b89b89a95d8e21381a46ad8dee2L59-R62) [[3]](diffhunk://#diff-d7d0507505083fa992eb4e75cb78c12977dfb415747ed0cacac0e39f786fe85cL43-R44) [[4]](diffhunk://#diff-d7d0507505083fa992eb4e75cb78c12977dfb415747ed0cacac0e39f786fe85cL69-R71)
* Modified the Salesforce service to support filtering campaigns by the `Public_sensibilis__c` field using the new `publicSensibilise` parameter in SOQL queries. [[1]](diffhunk://#diff-3f6c9087780f82e0ec45bd1b5cd2a316c2cb707572da1bd578e5ccedf97f775bL425-R426) [[2]](diffhunk://#diff-3f6c9087780f82e0ec45bd1b5cd2a316c2cb707572da1bd578e5ccedf97f775bR487-R493) [[3]](diffhunk://#diff-3f6c9087780f82e0ec45bd1b5cd2a316c2cb707572da1bd578e5ccedf97f775bR533)

**Salesforce integration:**

* Added `Public_sensibilis__c` to the list of Salesforce campaign attributes fetched and mapped in the backend.

These changes enable more granular event filtering and make the target audience information available to clients and consumers of the API.

[EN-9216]: https://entourage-asso.atlassian.net/browse/EN-9216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-9217]: https://entourage-asso.atlassian.net/browse/EN-9217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-9218]: https://entourage-asso.atlassian.net/browse/EN-9218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ