### PR TITLE
Add achievement ID to notification context and LinkedIn certification URL

### DIFF
--- a/src/gamification/config/achievements.config.ts
+++ b/src/gamification/config/achievements.config.ts
@@ -70,6 +70,8 @@ export interface AchievementCallbackUser {
  * eligibility context.
  */
 export interface AchievementCallbackContext {
+  /** The UUID of the UserAchievement record just created or renewed. */
+  achievementId: string;
   userId: string;
   userRole: UserRole;
   /** The badge's expiration date — use as nextEvaluationDate in notifications. */
@@ -184,6 +186,7 @@ export const ACHIEVEMENTS_CONFIG: AchievementDefinition[] = [
       ];
     },
     onGranted: async ({
+      achievementId,
       user,
       userId,
       userRole,
@@ -198,10 +201,12 @@ export const ACHIEVEMENTS_CONFIG: AchievementDefinition[] = [
       await mailsService.sendSuperEngagedAchievementMail(
         user,
         { conversationCount, responseRate: responseRate ?? 0 },
-        expireAt
+        expireAt,
+        achievementId
       );
     },
     onRenewed: async ({
+      achievementId,
       user,
       userId,
       userRole,
@@ -216,7 +221,8 @@ export const ACHIEVEMENTS_CONFIG: AchievementDefinition[] = [
       await mailsService.sendSuperEngagedAchievementMail(
         user,
         { conversationCount, responseRate: responseRate ?? 0 },
-        expireAt
+        expireAt,
+        achievementId
       );
     },
     onExpired: async ({

--- a/src/gamification/dto/public-achievement.dto.ts
+++ b/src/gamification/dto/public-achievement.dto.ts
@@ -1,0 +1,24 @@
+import { AchievementType } from 'src/gamification/config/achievements.config';
+import { UserAchievement } from 'src/gamification/models/user-achievement/user-achievement.model';
+import { User } from 'src/users/models';
+import { Gender } from 'src/users/users.types';
+
+export interface PublicAchievementDto {
+  firstName: string;
+  lastName: string;
+  gender: Gender;
+  achievedAt: string;
+  title: string;
+  achievementType: AchievementType;
+}
+
+export const generatePublicAchievementDto = (
+  achievement: UserAchievement & { user: User }
+): PublicAchievementDto => ({
+  firstName: achievement.user.firstName,
+  lastName: achievement.user.lastName,
+  gender: achievement.user.gender,
+  achievedAt: achievement.createdAt.toISOString(),
+  title: achievement.title,
+  achievementType: achievement.achievementType,
+});

--- a/src/gamification/gamification.controller.ts
+++ b/src/gamification/gamification.controller.ts
@@ -4,12 +4,13 @@ import {
   HttpCode,
   HttpStatus,
   Logger,
+  Param,
   ParseUUIDPipe,
   Post,
   UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { UserPayload } from 'src/auth/guards';
+import { Public, UserPayload } from 'src/auth/guards';
 import { UserPermissions, UserPermissionsGuard } from 'src/users/guards';
 import { Permissions, UserRole } from 'src/users/users.types';
 import { GamificationService } from './gamification.service';
@@ -21,6 +22,21 @@ export class GamificationController {
   private readonly logger = new Logger(GamificationController.name);
 
   constructor(private readonly gamificationService: GamificationService) {}
+
+  @Public()
+  @Get('achievements/:achievementId/public')
+  @ApiOperation({
+    summary: 'Get public certificate data for a single achievement',
+    description:
+      'Returns the coach name, gender, and achievement details for a certificate page. ' +
+      'The certificate remains accessible even if the badge has since expired. ' +
+      'Only publicly shareable types (e.g. SUPER_ENGAGED_COACH) are returned.',
+  })
+  getPublicAchievement(
+    @Param('achievementId', new ParseUUIDPipe()) achievementId: string
+  ) {
+    return this.gamificationService.getPublicAchievementById(achievementId);
+  }
 
   @Get('achievement-progression')
   @ApiBearerAuth()

--- a/src/gamification/gamification.service.ts
+++ b/src/gamification/gamification.service.ts
@@ -1,4 +1,10 @@
-import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import chunk from 'lodash/chunk';
 import { Op } from 'sequelize';
@@ -14,6 +20,10 @@ import {
   AchievementTypes,
   CriterionStat,
 } from './config/achievements.config';
+import {
+  generatePublicAchievementDto,
+  PublicAchievementDto,
+} from './dto/public-achievement.dto';
 import { generateAchievementSlackConfig } from './gamification.utils';
 import { UserAchievement } from './models/user-achievement/user-achievement.model';
 
@@ -56,6 +66,46 @@ export class GamificationService {
     return this.userAchievementModel.findAll({
       where: { userId, active: true },
     });
+  }
+
+  /**
+   * Returns the public certificate data for a single achievement.
+   *
+   * Only achievements of type SUPER_ENGAGED_COACH are publicly accessible.
+   * The certificate remains accessible even if the badge has since expired,
+   * because the achievement was legitimately earned at a point in time.
+   * Throws NotFoundException if the achievement does not exist or belongs
+   * to a non-public type.
+   */
+  async getPublicAchievementById(
+    achievementId: string
+  ): Promise<PublicAchievementDto> {
+    const PUBLIC_ACHIEVEMENT_TYPES: AchievementType[] = [
+      AchievementTypes.SUPER_ENGAGED_COACH,
+    ];
+
+    const achievement = await this.userAchievementModel.findOne({
+      where: {
+        id: achievementId,
+        achievementType: PUBLIC_ACHIEVEMENT_TYPES,
+      },
+      include: [
+        {
+          association: 'user',
+          attributes: ['firstName', 'lastName', 'gender'],
+        },
+      ],
+    });
+
+    if (!achievement) {
+      throw new NotFoundException('Achievement not found');
+    }
+
+    return generatePublicAchievementDto(
+      achievement as UserAchievement & {
+        user: { firstName: string; lastName: string; gender: string };
+      }
+    );
   }
 
   /**

--- a/src/gamification/gamification.service.ts
+++ b/src/gamification/gamification.service.ts
@@ -87,7 +87,7 @@ export class GamificationService {
     const achievement = await this.userAchievementModel.findOne({
       where: {
         id: achievementId,
-        achievementType: PUBLIC_ACHIEVEMENT_TYPES,
+        achievementType: { [Op.in]: PUBLIC_ACHIEVEMENT_TYPES },
       },
       include: [
         {

--- a/src/gamification/gamification.service.ts
+++ b/src/gamification/gamification.service.ts
@@ -231,6 +231,7 @@ export class GamificationService {
 
           if (achievement.onGranted) {
             await achievement.onGranted({
+              achievementId: userAchievement.id,
               userId,
               userRole: user.role,
               expireAt: userAchievement.expireAt,
@@ -313,6 +314,7 @@ export class GamificationService {
 
         const user = await this.usersService.findOne(achievement.userId);
         const baseContext = {
+          achievementId: achievement.id,
           userId: achievement.userId,
           userRole: user.role,
           user: {

--- a/src/mails/mails.service.ts
+++ b/src/mails/mails.service.ts
@@ -708,7 +708,7 @@ export class MailsService {
     this.logger.log(
       `Sending super engaged achievement mail to user with email ${user.email}`
     );
-    const certUrl = `${process.env.FRONT_URL}/coach_certification/${achievementId}`;
+    const certUrl = `${process.env.FRONT_URL}/coach-certification/${achievementId}`;
     const issueDate = new Date();
     const ctaUrlParams = new URLSearchParams({
       startTask: 'CERTIFICATION_NAME',

--- a/src/mails/mails.service.ts
+++ b/src/mails/mails.service.ts
@@ -702,11 +702,23 @@ export class MailsService {
       staffContact: InternalStaffContact;
     },
     stats: { conversationCount: number; responseRate: number },
-    nextEvaluationDate: Date
+    nextEvaluationDate: Date,
+    achievementId: string
   ) {
     this.logger.log(
       `Sending super engaged achievement mail to user with email ${user.email}`
     );
+    const certUrl = `${process.env.FRONT_URL}/coach_certification/${achievementId}`;
+    const issueDate = new Date();
+    const ctaUrlParams = new URLSearchParams({
+      startTask: 'CERTIFICATION_NAME',
+      name: 'Coach Entourage Pro',
+      organizationId: '42693016',
+      issueYear: String(issueDate.getFullYear()),
+      issueMonth: String(issueDate.getMonth() + 1),
+      certUrl,
+    });
+    const ctaUrl = `https://www.linkedin.com/profile/add?${ctaUrlParams.toString()}`;
     return this.queuesService.addToWorkQueue(Jobs.SEND_MAIL, {
       toEmail: user.email,
       templateId: MailjetTemplates.SUPER_ENGAGED_ACHIEVEMENT,
@@ -718,6 +730,7 @@ export class MailsService {
         conversationCount: stats.conversationCount,
         responseRate: stats.responseRate,
         staffContact: user.staffContact,
+        ctaUrl,
       },
     });
   }


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9240](https://entourage-asso.atlassian.net/browse/EN-9240) [EN-9241](https://entourage-asso.atlassian.net/browse/EN-9241) [EN-9242](https://entourage-asso.atlassian.net/browse/EN-9242)
**🚧 PR-Front :** [front/703](https://github.com/ReseauEntourage/entourage-job-front/pull/703)
**💬 Commentaire :**

This pull request introduces a new public certificate endpoint for achievements, specifically allowing public access to certificate data for certain achievement types (currently only "SUPER_ENGAGED_COACH"). It also ensures that the achievement ID is consistently passed through the achievement granting process and is included in the related notification emails, allowing for certificate URLs to be generated and shared.

**Public Achievement Certificate Feature:**

* Added a new public API endpoint `GET /achievements/:achievementId/public` in `gamification.controller.ts` to retrieve public certificate data for a single achievement, returning coach and achievement details for shareable types.
* Implemented `getPublicAchievementById` in `gamification.service.ts` to fetch and return certificate data for eligible achievements, throwing a `NotFoundException` if not found or not public.
* Introduced `PublicAchievementDto` and a helper function `generatePublicAchievementDto` to shape the public certificate response.

**Achievement Granting and Notification Improvements:**

* Updated the achievement granting flow to pass the `achievementId` through the context and callbacks, ensuring it is available for notifications and emails. [[1]](diffhunk://#diff-43e2eaf4e7195da3262d0fe939c8134440483abadc1fd7e24277a7257ac6bdd3R73-R74) [[2]](diffhunk://#diff-3b84519b81eac81f8a45967efc02574f3e3661e3ab833a55f966cea5568d28b6R284) [[3]](diffhunk://#diff-3b84519b81eac81f8a45967efc02574f3e3661e3ab833a55f966cea5568d28b6R367) [[4]](diffhunk://#diff-43e2eaf4e7195da3262d0fe939c8134440483abadc1fd7e24277a7257ac6bdd3R189) [[5]](diffhunk://#diff-43e2eaf4e7195da3262d0fe939c8134440483abadc1fd7e24277a7257ac6bdd3L201-R209) [[6]](diffhunk://#diff-43e2eaf4e7195da3262d0fe939c8134440483abadc1fd7e24277a7257ac6bdd3L219-R225)
* Modified `MailsService.sendSuperEngagedAchievementMail` to accept the `achievementId`, generate a public certificate URL, and include a LinkedIn "Add Certificate" call-to-action link in the notification email. [[1]](diffhunk://#diff-a897829bc6ed86b52d1a7336116247008ac1a0936ee9520feec464a6d063f94aL705-R721) [[2]](diffhunk://#diff-a897829bc6ed86b52d1a7336116247008ac1a0936ee9520feec464a6d063f94aR733)

[EN-9240]: https://entourage-asso.atlassian.net/browse/EN-9240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-9241]: https://entourage-asso.atlassian.net/browse/EN-9241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-9242]: https://entourage-asso.atlassian.net/browse/EN-9242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ