### PR TITLE
Add VoyageAI usage tracking in LlmMetricsService

### DIFF
--- a/src/external-services/llm-metrics/llm-metrics.service.ts
+++ b/src/external-services/llm-metrics/llm-metrics.service.ts
@@ -1,6 +1,7 @@
 import { Usage } from '@anthropic-ai/sdk/resources/messages/messages';
 import { Injectable, Logger } from '@nestjs/common';
 import { CompletionUsage } from 'openai/resources/completions';
+import { EmbedResponseUsage } from 'voyageai';
 import { tracer } from 'src/tracer';
 
 @Injectable()
@@ -54,6 +55,26 @@ export class LlmMetricsService {
         feature,
         prompt_tokens: usage.prompt_tokens,
         completion_tokens: usage.completion_tokens,
+      })}`
+    );
+
+    tracer.dogstatsd.flush();
+  }
+
+  recordVoyageAiUsage(
+    model: string,
+    usage: EmbedResponseUsage,
+    operation: string,
+    feature: string
+  ): void {
+    const tags = { model, provider: 'voyageai', operation, feature };
+    tracer.dogstatsd.increment('ai.tokens.input', usage.totalTokens ?? 0, tags);
+    this.logger.debug(
+      `VoyageAI usage recorded: ${JSON.stringify({
+        model,
+        operation,
+        feature,
+        total_tokens: usage.totalTokens,
       })}`
     );
 

--- a/src/external-services/voyageai/voyageai.module.ts
+++ b/src/external-services/voyageai/voyageai.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
+import { LlmMetricsModule } from '../llm-metrics/llm-metrics.module';
 import { VoyageAiService } from './voyageai.service';
 
 @Module({
-  imports: [],
+  imports: [LlmMetricsModule],
   providers: [VoyageAiService],
   exports: [VoyageAiService],
 })

--- a/src/external-services/voyageai/voyageai.service.ts
+++ b/src/external-services/voyageai/voyageai.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { VoyageAIClient, VoyageAIError } from 'voyageai';
 
+import { LlmMetricsService } from '../llm-metrics/llm-metrics.service';
 import { EMBEDDING_MODEL } from 'src/embeddings/embedding.config';
 
 @Injectable()
@@ -8,7 +9,7 @@ export class VoyageAiService {
   private readonly voyageAi: VoyageAIClient;
   private readonly logger = new Logger(VoyageAiService.name);
 
-  constructor() {
+  constructor(private readonly llmMetricsService: LlmMetricsService) {
     this.voyageAi = new VoyageAIClient({
       apiKey: process.env.VOYAGEAI_API_KEY ?? '',
     });
@@ -20,6 +21,14 @@ export class VoyageAiService {
         input: data,
         model: EMBEDDING_MODEL,
       });
+      if (response.usage) {
+        this.llmMetricsService.recordVoyageAiUsage(
+          EMBEDDING_MODEL,
+          response.usage,
+          'embedding',
+          'profile_recommendation'
+        );
+      }
       return response.data[0].embedding;
     } catch (error) {
       if (error instanceof VoyageAIError) {
@@ -55,6 +64,15 @@ export class VoyageAiService {
         input: dataArray,
         model: EMBEDDING_MODEL,
       });
+
+      if (response.usage) {
+        this.llmMetricsService.recordVoyageAiUsage(
+          EMBEDDING_MODEL,
+          response.usage,
+          'embedding',
+          'profile_recommendation'
+        );
+      }
 
       // The API returns an array of embeddings corresponding to the input array
       return response.data.map((item) => item.embedding);


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9254](https://entourage-asso.atlassian.net/browse/EN-9254)
**💬 Commentaire :**

This pull request adds tracking and recording of VoyageAI API usage metrics within the embedding workflow. The changes introduce a new method to the metrics service for handling VoyageAI usage data and ensure that each call to the embedding endpoint records relevant usage statistics for monitoring and observability.

**Metrics Integration and Usage Recording:**

* Added a new `recordVoyageAiUsage` method to `LlmMetricsService` to record VoyageAI token usage, including logging and metric flushing.
* Updated `VoyageAiService` to call `recordVoyageAiUsage` after each embedding request, ensuring usage is tracked for both single and batch embedding operations. [[1]](diffhunk://#diff-2772fc992e225eb8eaeb72a305d656bd035b90261d7e465958b04b3ae25e25e7R24-R31) [[2]](diffhunk://#diff-2772fc992e225eb8eaeb72a305d656bd035b90261d7e465958b04b3ae25e25e7R68-R76)

**Dependency Injection and Module Setup:**

* Modified `VoyageAiService` to inject `LlmMetricsService` as a dependency, enabling usage metric recording.
* Updated `VoyageAiModule` to import `LlmMetricsModule` so that the metrics service is available to `VoyageAiService`.

**Type Imports:**

* Imported `EmbedResponseUsage` from `voyageai` in `llm-metrics.service.ts` to type the usage parameter in the new metrics method.

[EN-9254]: https://entourage-asso.atlassian.net/browse/EN-9254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ