### PR TITLE
Add conversation type to model and associated services

### DIFF
--- a/src/db/migrations/20260617000000-add-type-to-conversations.js
+++ b/src/db/migrations/20260617000000-add-type-to-conversations.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Conversations', 'type', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'direct',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Conversations', 'type');
+  },
+};

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -40,7 +40,7 @@ import {
   generateSlackMsgConfigUserSuspiciousUser,
 } from './messaging.utils';
 import { ConversationParticipant, MessageMedia } from './models';
-import { Conversation } from './models/conversation.model';
+import { Conversation, ConversationType } from './models/conversation.model';
 import { Message } from './models/message.model';
 
 @Injectable()
@@ -392,10 +392,16 @@ export class MessagingService {
       new Set([...participantIds, authorId])
     );
 
+    const type =
+      uniqueParticipantIds.length > 2
+        ? ConversationType.GROUP
+        : ConversationType.DIRECT;
+
     const conversation = await this.conversationModel.create(
-      {},
+      { type },
       { transaction: options?.transaction }
     );
+
     await this.addMembersToConversation(
       conversation.id,
       uniqueParticipantIds,
@@ -1075,6 +1081,8 @@ export class MessagingService {
         )
         SELECT f."conversationId" AS id
         FROM first_message_per_participant f
+        JOIN "Conversations" c ON c.id = f."conversationId"
+        WHERE c.type = '${ConversationType.DIRECT}'
         GROUP BY f."conversationId"
         HAVING
           -- every participant has sent at least one message

--- a/src/messaging/messaging.utils.ts
+++ b/src/messaging/messaging.utils.ts
@@ -1,7 +1,7 @@
 import { SlackBlockConfig } from 'src/external-services/slack/slack.types';
 import { User } from 'src/users/models';
 import { ErrorMessagingMailingListInvalid } from './messaging.errors';
-import { Conversation } from './models';
+import { Conversation, ConversationType } from './models';
 
 export const generateSlackMsgConfigConversationReported = (
   conversation: Conversation,
@@ -110,6 +110,10 @@ export const determineIfShoudGiveFeedback = (
   feedbackRating: number | null,
   feedbackDate: Date | null
 ): boolean => {
+  if (conversation.type !== ConversationType.DIRECT) {
+    return false;
+  }
+
   const now = new Date();
   const thirtyDaysAgo = new Date(now);
   thirtyDaysAgo.setDate(now.getDate() - 30);

--- a/src/messaging/models/conversation.model.ts
+++ b/src/messaging/models/conversation.model.ts
@@ -15,6 +15,11 @@ import { User } from 'src/users/models';
 import { ConversationParticipant } from './conversation-participant.model';
 import { Message } from './message.model';
 
+export enum ConversationType {
+  DIRECT = 'direct',
+  GROUP = 'group',
+}
+
 @Table({ tableName: 'Conversations' })
 export class Conversation extends Model {
   @IsUUID(4)
@@ -22,6 +27,10 @@ export class Conversation extends Model {
   @Default(DataType.UUIDV4)
   @Column
   id: string;
+
+  @Default(ConversationType.DIRECT)
+  @Column(DataType.STRING)
+  type: ConversationType;
 
   @CreatedAt
   createdAt: Date;

--- a/src/messaging/models/index.ts
+++ b/src/messaging/models/index.ts
@@ -1,4 +1,4 @@
 export { Message } from './message.model';
-export { Conversation } from './conversation.model';
+export { Conversation, ConversationType } from './conversation.model';
 export { ConversationParticipant } from './conversation-participant.model';
 export { MessageMedia } from './message-media.model';

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -14,7 +14,7 @@ import { userFeatureFlagInclude } from 'src/feature-flags/models/user-feature-fl
 import { userAchievementInclude } from 'src/gamification/models/user-achievement/user-achievement.helper';
 import { MailsService } from 'src/mails/mails.service';
 import { userProfileAttributes } from 'src/messaging/messaging.attributes';
-import { Conversation } from 'src/messaging/models';
+import { Conversation, ConversationType } from 'src/messaging/models';
 import { Organization } from 'src/organizations/models';
 import { QueuesService } from 'src/queues/producers/queues.service';
 import { Jobs } from 'src/queues/queues.types';
@@ -1371,7 +1371,8 @@ export class UsersService {
         AND candidate.phone IS NOT NULL
         AND candidate.phone != ''
       WHERE
-        DATE(first_msg."firstMessageAt") = CURRENT_DATE - INTERVAL '${daysSinceFirstMessage} days'
+        c.type = '${ConversationType.DIRECT}'
+        AND DATE(first_msg."firstMessageAt") = CURRENT_DATE - INTERVAL '${daysSinceFirstMessage} days'
         AND NOT EXISTS (
           SELECT 1 FROM "Messages" m
           WHERE m."conversationId" = c.id
@@ -1434,7 +1435,8 @@ export class UsersService {
         ON cp."conversationId" = cp_other."conversationId"
         AND cp."userId" != cp_other."userId"
       JOIN "Users" u_other ON cp_other."userId" = u_other."id"
-      WHERE cp."feedbackDate" IS NULL
+      WHERE c.type = '${ConversationType.DIRECT}'
+        AND cp."feedbackDate" IS NULL
         AND cp."feedbackRating" IS NULL
         AND m."createdAt" = (
           SELECT MAX(m2."createdAt")


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9200](https://entourage-asso.atlassian.net/browse/EN-9200)
**🚧 PR-Front :** [front/707](https://github.com/ReseauEntourage/entourage-job-front/pull/707)
**💬 Commentaire :**

This pull request introduces support for conversation types (direct and group) in the messaging system. It adds a new `type` field to the `Conversations` table, updates the models and business logic to use this field, and ensures that certain features and queries apply only to direct conversations. The main goal is to distinguish between direct and group conversations throughout the codebase.

**Database and Model Updates:**

* Added a new `type` column to the `Conversations` table via a migration, defaulting to `'direct'`.
* Updated the `Conversation` model to include a `type` field and defined a `ConversationType` enum with values `DIRECT` and `GROUP`. [[1]](diffhunk://#diff-6586109b753deeecbf69a7235d30dfc42d5706ce655a681818792d7007ddde69R18-R22) [[2]](diffhunk://#diff-6586109b753deeecbf69a7235d30dfc42d5706ce655a681818792d7007ddde69R31-R34)
* Updated model exports to include `ConversationType` for use elsewhere in the codebase.

**Business Logic and Query Updates:**

* Modified conversation creation logic in `MessagingService` to set the `type` as `GROUP` if there are more than two participants, otherwise `DIRECT`.
* Updated SQL queries in both messaging and user services to filter or act only on direct conversations by checking `c.type = 'direct'`. [[1]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61R1084-R1085) [[2]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L1374-R1375) [[3]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L1437-R1439)

**Utility and Feature Logic:**

* Updated utility functions and feature logic to import and use `ConversationType`, and to ensure feedback logic only applies to direct conversations. [[1]](diffhunk://#diff-e2adfee0ef2995e91dda468051d6fc5779e71708d5385cad9b2d8dfc7b413888L4-R4) [[2]](diffhunk://#diff-e2adfee0ef2995e91dda468051d6fc5779e71708d5385cad9b2d8dfc7b413888R113-R116) [[3]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61L43-R43) [[4]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L17-R17)

[EN-9200]: https://entourage-asso.atlassian.net/browse/EN-9200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ