### PR TITLE
Update action button URL in reactivation email

### DIFF
--- a/src/mails/mails.service.ts
+++ b/src/mails/mails.service.ts
@@ -580,7 +580,7 @@ export class MailsService {
       templateId: MailjetTemplates.AUTO_SET_UNAVAILABLE,
       variables: {
         firstName: user.firstName,
-        ctaUrl: `${process.env.FRONT_URL}/backoffice/dashboard`,
+        ctaUrl: `${process.env.FRONT_URL}/backoffice/parametres?reactivate=true`,
         role: getRoleString(user),
         zone: user.zone,
         staffContact: user.staffContact,


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9236](https://entourage-asso.atlassian.net/browse/EN-9236)
**🚧 PR-Front :** [front/708](https://github.com/ReseauEntourage/entourage-job-front/pull/708)
**💬 Commentaire :**

This pull request makes a minor update to the URL used in the email template for the "auto set unavailable" notification. The call-to-action link now directs users to the parameters page with a `reactivate=true` query parameter, instead of the dashboard.

- Updated the `ctaUrl` variable in the `AUTO_SET_UNAVAILABLE` email template to point to `/backoffice/parametres?reactivate=true` instead of `/backoffice/dashboard` in `mails.service.ts`.

[EN-9236]: https://entourage-asso.atlassian.net/browse/EN-9236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ