### PR TITLE
Add conflict management for user creation

### DIFF
--- a/src/users-creation/users-creation.controller.ts
+++ b/src/users-creation/users-creation.controller.ts
@@ -310,6 +310,9 @@ export class UsersCreationController {
 
       return createdUser;
     } catch (err) {
+      if (err instanceof ConflictException) {
+        throw err;
+      }
       if ((err as Error).name === SequelizeUniqueConstraintError) {
         console.error('Duplicate email error:', err);
         throw new ConflictException();

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -85,7 +85,10 @@ export class UsersService {
 
   async create(createUserDto: Partial<User>) {
     if (createUserDto.email) {
-      const existingUser = await this.findOneByMail(createUserDto.email);
+      const existingUser = await this.userModel.findOne({
+        where: { email: createUserDto.email.toLowerCase() },
+        attributes: ['id'],
+      });
       if (existingUser) {
         throw new ConflictException();
       }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,4 +1,9 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  forwardRef,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { Op, QueryTypes, Sequelize } from 'sequelize';
 import { AuthService } from 'src/auth/auth.service';
@@ -79,6 +84,12 @@ export class UsersService {
   ) {}
 
   async create(createUserDto: Partial<User>) {
+    if (createUserDto.email) {
+      const existingUser = await this.findOneByMail(createUserDto.email);
+      if (existingUser) {
+        throw new ConflictException();
+      }
+    }
     return this.userModel.create(createUserDto, { hooks: true });
   }
 


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9418](https://entourage-asso.atlassian.net/browse/EN-9418)
**🚧 PR-Front :** [front/714](https://github.com/ReseauEntourage/entourage-job-front/pull/714)
**💬 Commentaire :**

This pull request adds improved handling for user creation conflicts by checking for existing users before attempting to create a new one and by refining error handling in the user creation controller. The main focus is on preventing duplicate user creation and providing clearer exception management.

**User creation conflict handling:**
* [`src/users/users.service.ts`](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577R87-R92): Added a pre-check in the `create` method to see if a user with the given email already exists, throwing a `ConflictException` if so.
* [`src/users/users.service.ts`](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L1-R6): Imported `ConflictException` from `@nestjs/common` to support the new exception logic.

**Error handling improvements:**
* [`src/users-creation/users-creation.controller.ts`](diffhunk://#diff-2c7d8a043f78535ab5d31ccc9c4c74dd0dc20cb5e99ae38717f14b389b0d7ca9R313-R315): Updated the `UsersCreationController` to immediately rethrow a `ConflictException` if encountered, ensuring the correct HTTP response is returned for duplicate user creation attempts.

[EN-9418]: https://entourage-asso.atlassian.net/browse/EN-9418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ