### PR TITLE
pnpm 11.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # INSTALL PNPM
-RUN npm install -g pnpm@10.30.3
+RUN npm install -g pnpm@11.15.0
 
 # NOTE: node_modules installation is done in entrypoint scripts
 # because the volume mount overwrites the image's node_modules

--- a/package.json
+++ b/package.json
@@ -157,5 +157,5 @@
     "tsconfig-paths": "^3.10.1",
     "typescript": "^6.0.0"
   },
-  "packageManager": "pnpm@10.31.0+sha512.e3927388bfaa8078ceb79b748ffc1e8274e84d75163e67bc22e06c0d3aed43dd153151cbf11d7f8301ff4acb98c68bdc5cadf6989532801ffafe3b3e4a63c268"
+  "packageManager": "pnpm@11.15.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,14 +1,13 @@
-onlyBuiltDependencies:
-  - sharp
-  - '@datadog/native-appsec'
-  - '@datadog/native-iast-taint-tracking'
-  - '@datadog/native-metrics'
-  - '@datadog/pprof'
-  - '@nestjs/core'
-  - dd-trace
-  - msgpackr-extract
-  - unrs-resolver
-
 supportedArchitectures:
   cpu: [x64, arm64]
   os: [current, linux, darwin]
+allowBuilds:
+  sharp: true
+  '@datadog/native-appsec': true
+  '@datadog/native-iast-taint-tracking': true
+  '@datadog/native-metrics': true
+  '@datadog/pprof': true
+  '@nestjs/core': true
+  dd-trace: true
+  msgpackr-extract: true
+  unrs-resolver: true


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9309](https://entourage-asso.atlassian.net/browse/EN-9309)
**🚧 PR-Front :** [front/716](https://github.com/ReseauEntourage/entourage-job-front/pull/716)
**💬 Commentaire :**

This pull request updates how build permissions for native dependencies are configured and upgrades the version of the package manager used in the project. These changes help ensure compatibility with the latest tooling and clarify which dependencies are allowed to be built.

**Dependency build configuration:**

* Replaces the deprecated `onlyBuiltDependencies` list with an `allowBuilds` mapping in `pnpm-workspace.yaml` to explicitly allow building specific native dependencies.

**Tooling upgrades:**

* Updates the `packageManager` field in `package.json` to use `pnpm@11.15.0` instead of `pnpm@10.31.0+sha512...`, ensuring the project uses the latest version of pnpm.

[EN-9309]: https://entourage-asso.atlassian.net/browse/EN-9309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ