### PR TITLE
Add eLearning completion checks for conversation creation and profile visibility

### DIFF
--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -32,10 +32,12 @@ import { ReportAbusePipe } from './dto/report-conversation.pipe';
 import { UserInConversation } from './guards/user-in-conversation';
 import {
   ErrorMessagingCantParticipate,
+  ErrorMessagingElearningNotCompleted,
   ErrorMessagingInvalidMessage,
   ErrorMessagingMailingListInvalid,
   ErrorMessagingNeedParticipantsOrConversationId,
   ErrorMessagingReachedDailyConversationLimit,
+  ErrorMessagingRecipientNotEligible,
 } from './messaging.errors';
 import { MessagingService } from './messaging.service';
 
@@ -94,6 +96,14 @@ export class MessagingController {
       } else if (error instanceof ErrorMessagingCantParticipate) {
         throw new UnauthorizedException(
           'Vous ne pouvez pas participer à cette conversation.'
+        );
+      } else if (error instanceof ErrorMessagingElearningNotCompleted) {
+        throw new UnauthorizedException(
+          "Vous devez terminer votre parcours de formation avant de pouvoir contacter d'autres membres. Rendez-vous sur la page Formations pour le compléter."
+        );
+      } else if (error instanceof ErrorMessagingRecipientNotEligible) {
+        throw new UnauthorizedException(
+          "Cette personne n'est pas disponible actuellement."
         );
       } else if (error instanceof ErrorMessagingReachedDailyConversationLimit) {
         throw new HttpException(

--- a/src/messaging/messaging.errors.ts
+++ b/src/messaging/messaging.errors.ts
@@ -32,3 +32,17 @@ export class ErrorMessagingMailingListInvalid extends Error {
     this.name = 'ErrorMessagingMailingListInvalid';
   }
 }
+
+export class ErrorMessagingElearningNotCompleted extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'ErrorMessagingElearningNotCompleted';
+  }
+}
+
+export class ErrorMessagingRecipientNotEligible extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'ErrorMessagingRecipientNotEligible';
+  }
+}

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -24,10 +24,12 @@ import {
 } from './messaging.attributes';
 import {
   ErrorMessagingCantParticipate,
+  ErrorMessagingElearningNotCompleted,
   ErrorMessagingInvalidMessage,
   ErrorMessagingMailingListInvalid,
   ErrorMessagingNeedParticipantsOrConversationId,
   ErrorMessagingReachedDailyConversationLimit,
+  ErrorMessagingRecipientNotEligible,
 } from './messaging.errors';
 import {
   messagingConversationIncludes,
@@ -195,8 +197,13 @@ export class MessagingService {
     userId: string,
     createMessageDto: CreateMessageDto
   ) {
-    // Ignore if the conversationId is not provided but the participantIds are
+    // New conversation: verify both the author and every recipient have
+    // completed their eLearning before allowing the conversation to start.
     if (!createMessageDto.conversationId && createMessageDto.participantIds) {
+      await this.assertElearningCompletedForNewConversation(
+        userId,
+        createMessageDto.participantIds
+      );
       return true;
     }
 
@@ -212,6 +219,36 @@ export class MessagingService {
     }
 
     return true;
+  }
+
+  /**
+   * Guards the creation of a new conversation (not a reply to an existing
+   * one): both the author and every designated recipient must have
+   * `elearningCompletedAt` set. Two distinct errors are thrown so the author
+   * gets an actionable message (own training incomplete) while a blocked
+   * recipient's training status is never revealed (neutral message).
+   */
+  private async assertElearningCompletedForNewConversation(
+    authorId: string,
+    recipientIds: string[]
+  ): Promise<void> {
+    const users = await this.usersService.findByIdsWithRelations([
+      authorId,
+      ...recipientIds,
+    ]);
+
+    const author = users.find((user) => user.id === authorId);
+    if (!author || !author.elearningCompletedAt) {
+      throw new ErrorMessagingElearningNotCompleted();
+    }
+
+    const hasIneligibleRecipient = recipientIds.some((recipientId) => {
+      const recipient = users.find((user) => user.id === recipientId);
+      return !recipient || !recipient.elearningCompletedAt;
+    });
+    if (hasIneligibleRecipient) {
+      throw new ErrorMessagingRecipientNotEligible();
+    }
   }
 
   /**

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -236,14 +236,15 @@ export class MessagingService {
       authorId,
       ...recipientIds,
     ]);
+    const usersById = new Map(users.map((user) => [user.id, user]));
 
-    const author = users.find((user) => user.id === authorId);
+    const author = usersById.get(authorId);
     if (!author || !author.elearningCompletedAt) {
       throw new ErrorMessagingElearningNotCompleted();
     }
 
     const hasIneligibleRecipient = recipientIds.some((recipientId) => {
-      const recipient = users.find((user) => user.id === recipientId);
+      const recipient = usersById.get(recipientId);
       return !recipient || !recipient.elearningCompletedAt;
     });
     if (hasIneligibleRecipient) {

--- a/src/user-profiles/recommendations/user-profile-recommendations-ai.service.ts
+++ b/src/user-profiles/recommendations/user-profile-recommendations-ai.service.ts
@@ -222,6 +222,7 @@ export class UserProfileRecommendationsService extends UserProfileRecommendation
         AND u.id                  != :userId
         AND u.role                IN (${rolesPlaceholder})
         AND u."onboardingStatus"  = :onboardingStatusCompleted
+        AND u."elearningCompletedAt" IS NOT NULL
         ${excludeClause}
       ORDER BY upe.embedding <=> ${vec}
       LIMIT :annPoolSize
@@ -265,6 +266,7 @@ export class UserProfileRecommendationsService extends UserProfileRecommendation
         AND u.id                  != :userId
         AND u.role                IN (${rolesPlaceholder})
         AND u."onboardingStatus"  = :onboardingStatusCompleted
+        AND u."elearningCompletedAt" IS NOT NULL
         ${excludeClause}
       ORDER BY upe.embedding <=> ${vec}
       LIMIT :annPoolSize

--- a/src/user-profiles/user-profiles.controller.ts
+++ b/src/user-profiles/user-profiles.controller.ts
@@ -48,6 +48,7 @@ import {
 } from './recommendations/user-profile-recommendations-ai.service';
 import { UserProfilesService } from './user-profiles.service';
 import { ContactTypeEnum } from './user-profiles.types';
+import { isProfileVisibilityEligible } from './user-profiles.utils';
 
 @ApiTags('UserProfiles')
 @ApiBearerAuth()
@@ -377,7 +378,7 @@ export class UserProfilesController {
       true
     );
 
-    if (!user || !userProfile) {
+    if (!user || !userProfile || !isProfileVisibilityEligible(user)) {
       throw new NotFoundException();
     }
 

--- a/src/user-profiles/user-profiles.service.ts
+++ b/src/user-profiles/user-profiles.service.ts
@@ -42,13 +42,7 @@ import { QueuesService } from 'src/queues/producers/queues.service';
 import { Jobs } from 'src/queues/queues.types';
 import { User } from 'src/users/models';
 import { UsersService } from 'src/users/users.service';
-import {
-  Gender,
-  Genders,
-  OnboardingStatus,
-  UserRole,
-  UserRoles,
-} from 'src/users/users.types';
+import { Gender, Genders, UserRole, UserRoles } from 'src/users/users.types';
 import { UsersStatsService } from 'src/users-stats/users-stats.service';
 import { getDepartmentLocative } from 'src/utils/misc/department-locative';
 import {
@@ -80,7 +74,10 @@ import {
 import { SCORING_WEIGHTS } from './recommendations/scoring.config';
 import { UserProfileRecommendationsService } from './recommendations/user-profile-recommendations-ai.service';
 import { ContactTypeEnum } from './user-profiles.types';
-import { userProfileSearchQuery } from './user-profiles.utils';
+import {
+  profileVisibilityEligibilityWhere,
+  userProfileSearchQuery,
+} from './user-profiles.utils';
 
 const LINKEDIN_ENTOURAGE_PRO_ORG_ID = '42693016';
 
@@ -296,7 +293,7 @@ export class UserProfilesService {
           where: {
             role,
             lastConnection: { [Op.ne]: null },
-            onboardingStatus: OnboardingStatus.COMPLETED,
+            ...profileVisibilityEligibilityWhere,
           },
           required: true,
           ...(hasSuperCoachBadge
@@ -477,7 +474,7 @@ export class UserProfilesService {
             id: { [Op.in]: candidateUserIds },
             role: normalizedRole,
             lastConnection: { [Op.ne]: null },
-            onboardingStatus: OnboardingStatus.COMPLETED,
+            ...profileVisibilityEligibilityWhere,
           },
           required: true,
           ...(hasSuperCoachBadge

--- a/src/user-profiles/user-profiles.utils.ts
+++ b/src/user-profiles/user-profiles.utils.ts
@@ -1,3 +1,6 @@
+import { Op, WhereOptions } from 'sequelize';
+import { User } from 'src/users/models';
+import { OnboardingStatus } from 'src/users/users.types';
 import { searchInColumnWhereOption } from 'src/utils/misc';
 
 export function userProfileSearchQuery(query = '') {
@@ -11,4 +14,32 @@ export function userProfileSearchQuery(query = '') {
     ),
     searchInColumnWhereOption('currentJob', query, true),
   ];
+}
+
+/**
+ * Single source of truth for whether a profile is eligible to be visible to
+ * others (directory, search, recommendations, detail page): onboarding must
+ * be completed AND the eLearning modules must be completed.
+ *
+ * Raw-SQL equivalent used in `UserProfileRecommendationsService`'s hand-written
+ * CTEs (a Sequelize `WhereOptions` cannot be interpolated into raw SQL):
+ *   u."onboardingStatus" = :onboardingStatusCompleted AND u."elearningCompletedAt" IS NOT NULL
+ */
+export const profileVisibilityEligibilityWhere: WhereOptions<User> = {
+  onboardingStatus: OnboardingStatus.COMPLETED,
+  elearningCompletedAt: { [Op.ne]: null },
+};
+
+/**
+ * Same condition as `profileVisibilityEligibilityWhere`, expressed as a plain
+ * predicate for use on an already-fetched user (e.g. the profile detail route,
+ * which loads the user once and cannot re-express the check as a SQL filter).
+ */
+export function isProfileVisibilityEligible(
+  user: Pick<User, 'onboardingStatus' | 'elearningCompletedAt'>
+): boolean {
+  return (
+    user.onboardingStatus === OnboardingStatus.COMPLETED &&
+    user.elearningCompletedAt != null
+  );
 }

--- a/src/users/models/user.attributes.ts
+++ b/src/users/models/user.attributes.ts
@@ -19,6 +19,7 @@ export const UserAttributes = [
   'onboardingStatus',
   'onboardingCompletedAt',
   'onboardingWebinarSkippedAt',
+  'elearningCompletedAt',
 ] as const;
 
 export type UserAttribute = (typeof UserAttributes)[number];

--- a/tests/auth/auth.e2e-spec.ts
+++ b/tests/auth/auth.e2e-spec.ts
@@ -242,6 +242,7 @@ describe('Auth', () => {
           lastConnection: response.body.lastConnection,
           createdAt: response.body.createdAt,
           onboardingCompletedAt: response.body.onboardingCompletedAt,
+          elearningCompletedAt: response.body.elearningCompletedAt,
         });
       });
       it('Should return 400, if not matching passwords', async () => {

--- a/tests/elearning/elearning.e2e-spec.ts
+++ b/tests/elearning/elearning.e2e-spec.ts
@@ -215,6 +215,7 @@ describe('Elearning', () => {
     it('Should set elearningCompletedAt only when the last unit of the role is completed', async () => {
       const loggedIn = await usersHelper.createLoggedInUser({
         role: UserRoles.CANDIDATE,
+        elearningCompletedAt: null,
       });
 
       const unit1 = await elearningUnitFactory.create(

--- a/tests/messaging/messaging.e2e-spec.ts
+++ b/tests/messaging/messaging.e2e-spec.ts
@@ -325,6 +325,104 @@ describe('MESSAGING', () => {
         expect(response.status).toBe(401);
       });
 
+      describe('Elearning completion gate', () => {
+        it('should return 401 and not create a conversation when the author has not completed elearning', async () => {
+          const loggedInIneligibleCandidate =
+            await usersHelper.createLoggedInUser({
+              role: UserRoles.CANDIDATE,
+              elearningCompletedAt: null,
+            });
+          const nbConversationBefore =
+            await messagingHelper.countConversation();
+
+          const response: APIResponse<MessagingController['postMessage']> =
+            await request(server)
+              .post(`/messaging/messages`)
+              .send({
+                content: 'Super message',
+                participantIds: [loggedInCoach.user.id],
+              })
+              .set(
+                'authorization',
+                `Bearer ${loggedInIneligibleCandidate.token}`
+              );
+
+          const nbConversationAfter = await messagingHelper.countConversation();
+
+          expect(response.status).toBe(401);
+          expect(
+            (response.body as unknown as { message: string }).message
+          ).toMatch(/formation/i);
+          expect(nbConversationAfter).toBe(nbConversationBefore);
+        });
+
+        it('should return 401 and not create a conversation when the recipient has not completed elearning, without revealing the reason', async () => {
+          const loggedInIneligibleCoach = await usersHelper.createLoggedInUser({
+            role: UserRoles.COACH,
+            elearningCompletedAt: null,
+          });
+          const nbConversationBefore =
+            await messagingHelper.countConversation();
+
+          const response: APIResponse<MessagingController['postMessage']> =
+            await request(server)
+              .post(`/messaging/messages`)
+              .send({
+                content: 'Super message',
+                participantIds: [loggedInIneligibleCoach.user.id],
+              })
+              .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+          const nbConversationAfter = await messagingHelper.countConversation();
+
+          expect(response.status).toBe(401);
+          expect(
+            (response.body as unknown as { message: string }).message
+          ).not.toMatch(/formation/i);
+          expect(nbConversationAfter).toBe(nbConversationBefore);
+        });
+
+        it('should return 201 and create a conversation when both the author and the recipient have completed elearning', async () => {
+          const response: APIResponse<MessagingController['postMessage']> =
+            await request(server)
+              .post(`/messaging/messages`)
+              .send({
+                content: 'Super message',
+                participantIds: [loggedInCoach.user.id],
+              })
+              .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+          expect(response.status).toBe(201);
+        });
+
+        it('should return 201 when replying to an existing conversation, regardless of elearning completion', async () => {
+          const loggedInIneligibleCandidate =
+            await usersHelper.createLoggedInUser({
+              role: UserRoles.CANDIDATE,
+              elearningCompletedAt: null,
+            });
+          const conversation = await conversationFactory.create();
+          await messagingHelper.associationParticipantsToConversation(
+            conversation.id,
+            [loggedInIneligibleCandidate.user.id, loggedInCoach.user.id]
+          );
+
+          const response: APIResponse<MessagingController['postMessage']> =
+            await request(server)
+              .post(`/messaging/messages`)
+              .send({
+                content: 'Super message',
+                conversationId: conversation.id,
+              })
+              .set(
+                'authorization',
+                `Bearer ${loggedInIneligibleCandidate.token}`
+              );
+
+          expect(response.status).toBe(201);
+        });
+      });
+
       it('should return 400 if neither the participantIds nor the conversationId is provided', async () => {
         const response: APIResponse<MessagingController['postMessage']> =
           await request(server)

--- a/tests/user-creation/user-creation.e2e-spec.ts
+++ b/tests/user-creation/user-creation.e2e-spec.ts
@@ -166,6 +166,7 @@ describe('UserCreation', () => {
         company,
         onboardingCompletedAt,
         onboardingStatus,
+        elearningCompletedAt,
         ...user
       } = await userFactory.create({}, {}, false);
       const response: APIResponse<UsersCreationController['createUser']> =
@@ -197,6 +198,7 @@ describe('UserCreation', () => {
         company,
         onboardingCompletedAt,
         onboardingStatus,
+        elearningCompletedAt,
         ...user
       } = await userFactory.create({}, {}, false);
       const response: APIResponse<UsersCreationController['createUser']> =
@@ -294,6 +296,7 @@ describe('UserCreation', () => {
         company,
         onboardingCompletedAt,
         onboardingStatus,
+        elearningCompletedAt,
         ...candidate
       } = await userFactory.create(
         {
@@ -329,6 +332,7 @@ describe('UserCreation', () => {
           company,
           onboardingCompletedAt,
           onboardingStatus,
+          elearningCompletedAt,
           ...candidate
         } = await userFactory.create({ role: UserRoles.CANDIDATE }, {}, false);
         const response: APIResponse<UsersCreationController['createUser']> =
@@ -361,6 +365,7 @@ describe('UserCreation', () => {
           company,
           onboardingCompletedAt,
           onboardingStatus,
+          elearningCompletedAt,
           ...coach
         } = await userFactory.create({ role: UserRoles.COACH }, {}, false);
 
@@ -393,6 +398,7 @@ describe('UserCreation', () => {
           staffContact,
           onboardingCompletedAt,
           onboardingStatus,
+          elearningCompletedAt,
           ...candidate
         } = await userFactory.create({ role: UserRoles.CANDIDATE }, {}, false);
 
@@ -422,6 +428,7 @@ describe('UserCreation', () => {
           staffContact,
           onboardingCompletedAt,
           onboardingStatus,
+          elearningCompletedAt,
           ...coach
         } = await userFactory.create({ role: UserRoles.COACH }, {}, false);
 

--- a/tests/user-profiles/user-profiles.e2e-spec.ts
+++ b/tests/user-profiles/user-profiles.e2e-spec.ts
@@ -20,7 +20,7 @@ import { UserProfileRecommendationsService } from 'src/user-profiles/recommendat
 import { UserProfileRecommendationsLegacyService } from 'src/user-profiles/recommendations/user-profile-recommendations-legacy.service';
 import { UserProfilesController } from 'src/user-profiles/user-profiles.controller';
 import { User } from 'src/users/models';
-import { UserRoles } from 'src/users/users.types';
+import { OnboardingStatus, UserRoles } from 'src/users/users.types';
 import { APIResponse } from 'src/utils/types';
 import { ZoneName } from 'src/utils/types/zones.types';
 import { BusinessSectorHelper } from 'tests/business-sectors/business-sector.helper';
@@ -297,6 +297,55 @@ describe('UserProfiles', () => {
                 .get(`${route}/profile?offset=0&limit=25`)
                 .set('authorization', `Bearer ${loggedInCandidate.token}`);
             expect(response.status).toBe(400);
+          });
+        });
+        describe('/profile?limit=&offset=&role[]= - Elearning completion gate (visibility)', () => {
+          it('Should not include a profile with onboarding completed but elearning not completed', async () => {
+            const loggedInCandidate = await usersHelper.createLoggedInUser({
+              role: UserRoles.CANDIDATE,
+            });
+            const ineligibleCoach = await userFactory.create({
+              role: UserRoles.COACH,
+              elearningCompletedAt: null,
+            });
+
+            const response: APIResponse<UserProfilesController['findAll']> =
+              await request(server)
+                .get(
+                  `${route}/profile?offset=0&limit=25&role[]=${UserRoles.COACH}`
+                )
+                .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+            expect(response.status).toBe(200);
+            expect(response.body.map((profile) => profile.id)).not.toContain(
+              ineligibleCoach.id
+            );
+          });
+
+          it('Should allow a user who has not completed elearning to see eligible profiles of others', async () => {
+            const loggedInIneligibleCandidate =
+              await usersHelper.createLoggedInUser({
+                role: UserRoles.CANDIDATE,
+                elearningCompletedAt: null,
+              });
+            const eligibleCoach = await userFactory.create({
+              role: UserRoles.COACH,
+            });
+
+            const response: APIResponse<UserProfilesController['findAll']> =
+              await request(server)
+                .get(
+                  `${route}/profile?offset=0&limit=25&role[]=${UserRoles.COACH}`
+                )
+                .set(
+                  'authorization',
+                  `Bearer ${loggedInIneligibleCandidate.token}`
+                );
+
+            expect(response.status).toBe(200);
+            expect(response.body.map((profile) => profile.id)).toContain(
+              eligibleCoach.id
+            );
           });
         });
         describe('/profile?limit=&offset=&role[]= - Get paginated and creation date sorted users filtered by role', () => {
@@ -1554,6 +1603,28 @@ describe('UserProfiles', () => {
               ),
             })
           );
+        });
+
+        it('Should return 404, if the targeted profile has not completed onboarding', async () => {
+          const ineligibleUser = await userFactory.create({
+            onboardingStatus: OnboardingStatus.IN_PROGRESS,
+          });
+          const response: APIResponse<UserProfilesController['findByUserId']> =
+            await request(server)
+              .get(`${route}/profile/${ineligibleUser.id}`)
+              .set('authorization', `Bearer ${loggedInUser.token}`);
+          expect(response.status).toBe(404);
+        });
+
+        it('Should return 404, if the targeted profile has completed onboarding but not elearning', async () => {
+          const ineligibleUser = await userFactory.create({
+            elearningCompletedAt: null,
+          });
+          const response: APIResponse<UserProfilesController['findByUserId']> =
+            await request(server)
+              .get(`${route}/profile/${ineligibleUser.id}`)
+              .set('authorization', `Bearer ${loggedInUser.token}`);
+          expect(response.status).toBe(404);
         });
       });
     });

--- a/tests/users/user.factory.ts
+++ b/tests/users/user.factory.ts
@@ -48,11 +48,13 @@ export class UserFactory implements Factory<User> {
       onboardingCompletedAt: props.onboardingCompletedAt || moment().toDate(),
       // Defaults to an eligible (elearning completed) user, matching the
       // onboarding default above — pass `elearningCompletedAt: null`
-      // explicitly to build an ineligible test user.
+      // explicitly to build an ineligible test user. An explicit
+      // `undefined` (e.g. from a merged props object) is treated the
+      // same as "not provided" rather than as an override.
       elearningCompletedAt:
-        'elearningCompletedAt' in props
-          ? props.elearningCompletedAt
-          : moment().toDate(),
+        props.elearningCompletedAt === undefined
+          ? moment().toDate()
+          : props.elearningCompletedAt,
     };
 
     return {

--- a/tests/users/user.factory.ts
+++ b/tests/users/user.factory.ts
@@ -46,6 +46,13 @@ export class UserFactory implements Factory<User> {
       updatedAt: moment().toDate(),
       onboardingStatus: props.onboardingStatus || OnboardingStatus.COMPLETED,
       onboardingCompletedAt: props.onboardingCompletedAt || moment().toDate(),
+      // Defaults to an eligible (elearning completed) user, matching the
+      // onboarding default above — pass `elearningCompletedAt: null`
+      // explicitly to build an ineligible test user.
+      elearningCompletedAt:
+        'elearningCompletedAt' in props
+          ? props.elearningCompletedAt
+          : moment().toDate(),
     };
 
     return {


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9329](https://entourage-asso.atlassian.net/browse/EN-9329)
**💬 Commentaire :**

This pull request introduces a new eligibility requirement: users must have completed their eLearning modules (`elearningCompletedAt` set) to be visible in the directory, returned in search/recommendations, or to initiate new conversations. The change is enforced consistently across the backend (controllers, services, and raw SQL), and is thoroughly tested with new and updated end-to-end tests.

**Eligibility enforcement for user visibility and messaging:**

* Added a single source of truth for profile visibility eligibility (`profileVisibilityEligibilityWhere` and `isProfileVisibilityEligible` in `user-profiles.utils.ts`), requiring both onboarding completion and eLearning completion for a profile to be visible in search, recommendations, and detail pages. [[1]](diffhunk://#diff-b5ea9df903db4340b028b3fc8cb4570b7eb5ede5530c11a922be23eeedea8ed0R1-R3) [[2]](diffhunk://#diff-c7afca6ec9640e03f8b854185415abded89e522c22f4aa273686ef2c6d05448cL380-R381) [[3]](diffhunk://#diff-68a3f696de85f42a907de2fdfb124fc1cf7b5460e867943e1bc7f00f30ba4648L299-R296) [[4]](diffhunk://#diff-68a3f696de85f42a907de2fdfb124fc1cf7b5460e867943e1bc7f00f30ba4648L480-R477)
* Updated raw SQL queries for AI-powered recommendations to exclude users who have not completed eLearning (`elearningCompletedAt IS NOT NULL`). [[1]](diffhunk://#diff-c8f33c3bfab6ee95569360b447a160ffcff2e604552fd27fa768e5a297845328R225) [[2]](diffhunk://#diff-c8f33c3bfab6ee95569360b447a160ffcff2e604552fd27fa768e5a297845328R269)
* The messaging system now blocks the creation of new conversations unless both the author and all recipients have completed eLearning, with distinct error handling to avoid leaking recipient status. [[1]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61L198-R206) [[2]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61R224-R253) [[3]](diffhunk://#diff-0ecf2ba7c7238e8b26eb6fb34b9afec7ab003d515f9fec6034196eced83cb47fR100-R107) [[4]](diffhunk://#diff-58e001bded536aae53d7da8f391a45f58496ad27868b1f9cb4e0bb3a20b74dc6R35-R48)
* Added the `elearningCompletedAt` attribute to the user model and ensured it is set by default in test user factories, unless explicitly overridden. [[1]](diffhunk://#diff-0fcc7520abf1383ad676104254b6f61952a00eda14c68391fc781a324a3ac20cR22) [[2]](diffhunk://#diff-6dafa66faaaa7a728b09f90f80c87b465726e839608c8b440e5882f0d940ed8eR49-R55)

**Testing and validation:**

* Added and updated end-to-end tests to cover all new eligibility requirements for messaging and profile visibility, including checks for both author and recipient eLearning status and visibility in search and detail endpoints. [[1]](diffhunk://#diff-35123517d38609f9e2be171fa6b2b5285ddf8a7cb41191d7402a0612a93f9e3bR328-R425) [[2]](diffhunk://#diff-7511523e7ec577afe33e8925b8f708bc9a52389f8136e2189b7a93260fd33e7fR302-R350) [[3]](diffhunk://#diff-7511523e7ec577afe33e8925b8f708bc9a52389f8136e2189b7a93260fd33e7fR1607-R1628)

These changes ensure that only users who have completed both onboarding and eLearning are visible and can initiate new conversations, improving the integrity of user interactions on the platform.

[EN-9329]: https://entourage-asso.atlassian.net/browse/EN-9329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ