### PR TITLE
Refactor eLearning completion creation to return existing without side effects

### DIFF
--- a/src/elearning/elearning.controller.ts
+++ b/src/elearning/elearning.controller.ts
@@ -8,6 +8,7 @@ import {
   Query,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { UserPayload } from 'src/auth/guards';
 import type { UserRole } from 'src/users/users.types';
 import { ElearningService } from './elearning.service';
@@ -30,12 +31,18 @@ export class ElearningController {
     return this.elearningService.findAllUnits(limit, offset, userRole, userId);
   }
 
+  @Throttle(60, 60)
   @Post('/units/:unitId/completions')
   async createElearningCompletion(
     @UserPayload('id') userId: string,
+    @UserPayload('role') userRole: UserRole,
     @Param('unitId')
     unitId: string
   ) {
-    return this.elearningService.createElearningCompletion(userId, unitId);
+    return this.elearningService.createElearningCompletion(
+      userId,
+      unitId,
+      userRole
+    );
   }
 }

--- a/src/elearning/elearning.controller.ts
+++ b/src/elearning/elearning.controller.ts
@@ -1,7 +1,6 @@
 import {
   Controller,
   DefaultValuePipe,
-  Delete,
   Get,
   Param,
   ParseIntPipe,
@@ -38,14 +37,5 @@ export class ElearningController {
     unitId: string
   ) {
     return this.elearningService.createElearningCompletion(userId, unitId);
-  }
-
-  @Delete('/units/:unitId/completions')
-  async deleteElearningCompletion(
-    @UserPayload('id') userId: string,
-    @Param('unitId')
-    unitId: string
-  ) {
-    return this.elearningService.deleteElearningCompletion(userId, unitId);
   }
 }

--- a/src/elearning/elearning.service.ts
+++ b/src/elearning/elearning.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { MailsService } from 'src/mails/mails.service';
 import { User } from 'src/users/models';
@@ -10,6 +15,7 @@ import {
 } from './elearning.attributes';
 import { generateElearningUnitIncludes } from './elearning.includes';
 import { ElearningCompletion } from './models/elearning-completion.model';
+import { ElearningUnitRole } from './models/elearning-unit-role.model';
 import { ElearningUnit } from './models/elearning-unit.model';
 
 @Injectable()
@@ -18,6 +24,8 @@ export class ElearningService {
   constructor(
     @InjectModel(ElearningUnit)
     private elearningUnitModel: typeof ElearningUnit,
+    @InjectModel(ElearningUnitRole)
+    private elearningUnitRoleModel: typeof ElearningUnitRole,
     @InjectModel(ElearningCompletion)
     private elearningCompletionModel: typeof ElearningCompletion,
     readonly mailsService: MailsService,
@@ -66,14 +74,30 @@ export class ElearningService {
    * side effects on the original completion).
    * @param userId The ID of the user
    * @param unitId The ID of the elearning unit
+   * @param userRole The role of the current user
    * @returns The existing or newly created ElearningCompletion
    * @throws NotFoundException if the elearning unit does not exist
+   * @throws ForbiddenException if the elearning unit does not belong to the user's role
    */
-  async createElearningCompletion(userId: string, unitId: string) {
+  async createElearningCompletion(
+    userId: string,
+    unitId: string,
+    userRole: UserRole
+  ) {
     // Check the unitId exists
     const unit = await this.elearningUnitModel.findByPk(unitId);
     if (!unit) {
       throw new NotFoundException('Elearning unit not found');
+    }
+
+    // Check the unit belongs to the current user's role
+    const unitRole = await this.elearningUnitRoleModel.findOne({
+      where: { unitId, role: userRole },
+    });
+    if (!unitRole) {
+      throw new ForbiddenException(
+        'Elearning unit does not belong to the user role'
+      );
     }
 
     // Check if the completion already exists

--- a/src/elearning/elearning.service.ts
+++ b/src/elearning/elearning.service.ts
@@ -1,9 +1,4 @@
-import {
-  ConflictException,
-  Injectable,
-  Logger,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { MailsService } from 'src/mails/mails.service';
 import { User } from 'src/users/models';
@@ -66,11 +61,12 @@ export class ElearningService {
   }
 
   /**
-   * Create a new elearning completion for a user and unit.
+   * Find or create an elearning completion for a user and unit. If a completion
+   * already exists, it is returned as-is (a replay never mutates or re-triggers
+   * side effects on the original completion).
    * @param userId The ID of the user
    * @param unitId The ID of the elearning unit
-   * @returns The created ElearningCompletion
-   * @throws ConflictException if the completion already exists
+   * @returns The existing or newly created ElearningCompletion
    * @throws NotFoundException if the elearning unit does not exist
    */
   async createElearningCompletion(userId: string, unitId: string) {
@@ -85,9 +81,7 @@ export class ElearningService {
       where: { userId, unitId },
     });
     if (existingCompletion) {
-      throw new ConflictException(
-        'Completion already exists for this user and unit'
-      );
+      return this.findOneElearningCompletionById(existingCompletion.id);
     }
 
     // Create the completion
@@ -100,26 +94,6 @@ export class ElearningService {
     await this.onElearningUnitCompleted(userId);
 
     return this.findOneElearningCompletionById(completion.id);
-  }
-
-  /**
-   * Delete an elearning completion for a user and unit.
-   * @param userId The ID of the user
-   * @param unitId The ID of the elearning unit
-   * @returns void
-   * @throws NotFoundException if the completion does not exist
-   */
-  async deleteElearningCompletion(userId: string, unitId: string) {
-    const completion = await this.elearningCompletionModel.findOne({
-      where: { userId, unitId },
-    });
-    if (!completion) {
-      throw new NotFoundException(
-        'Completion not found for this user and unit'
-      );
-    }
-
-    await completion.destroy();
   }
 
   async allUnitsNotCompletedByUser(user: User): Promise<ElearningUnit[]> {

--- a/src/elearning/elearning.service.ts
+++ b/src/elearning/elearning.service.ts
@@ -8,7 +8,11 @@ import { InjectModel } from '@nestjs/sequelize';
 import { MailsService } from 'src/mails/mails.service';
 import { User } from 'src/users/models';
 import { UsersService } from 'src/users/users.service';
-import { UserRole, UserRoles } from 'src/users/users.types';
+import {
+  SequelizeUniqueConstraintError,
+  UserRole,
+  UserRoles,
+} from 'src/users/users.types';
 import {
   ELEARNING_UNIT_ATTRIBUTES,
   ELEARNING_COMPLETION_ATTRIBUTES,
@@ -103,21 +107,37 @@ export class ElearningService {
     // Check if the completion already exists
     const existingCompletion = await this.elearningCompletionModel.findOne({
       where: { userId, unitId },
+      attributes: ELEARNING_COMPLETION_ATTRIBUTES,
     });
     if (existingCompletion) {
-      return this.findOneElearningCompletionById(existingCompletion.id);
+      return existingCompletion;
     }
 
-    // Create the completion
-    const completion = await this.elearningCompletionModel.create({
-      userId,
-      unitId,
-      validatedAt: new Date(),
-    });
+    // Create the completion. Two concurrent replays can both pass the
+    // findOne check above; the unique (userId, unitId) constraint then
+    // rejects the second create, so we fall back to returning the row the
+    // other request just inserted instead of surfacing a 500.
+    let completionId: string;
+    try {
+      const completion = await this.elearningCompletionModel.create({
+        userId,
+        unitId,
+        validatedAt: new Date(),
+      });
+      completionId = completion.id;
+    } catch (err) {
+      if ((err as Error).name === SequelizeUniqueConstraintError) {
+        return this.elearningCompletionModel.findOne({
+          where: { userId, unitId },
+          attributes: ELEARNING_COMPLETION_ATTRIBUTES,
+        });
+      }
+      throw err;
+    }
 
     await this.onElearningUnitCompleted(userId);
 
-    return this.findOneElearningCompletionById(completion.id);
+    return this.findOneElearningCompletionById(completionId);
   }
 
   async allUnitsNotCompletedByUser(user: User): Promise<ElearningUnit[]> {

--- a/tests/elearning/elearning.e2e-spec.ts
+++ b/tests/elearning/elearning.e2e-spec.ts
@@ -211,27 +211,29 @@ describe('Elearning', () => {
         'sendAllElearningUnitsCompletedMail'
       );
 
-      const first = await request(server)
-        .post(`${route}/units/${unit.id}/completions`)
-        .set('authorization', `Bearer ${loggedIn.token}`);
-      expect(first.status).toBe(201);
-      expect(mailSpy).toHaveBeenCalledTimes(1);
+      try {
+        const first = await request(server)
+          .post(`${route}/units/${unit.id}/completions`)
+          .set('authorization', `Bearer ${loggedIn.token}`);
+        expect(first.status).toBe(201);
+        expect(mailSpy).toHaveBeenCalledTimes(1);
 
-      const second = await request(server)
-        .post(`${route}/units/${unit.id}/completions`)
-        .set('authorization', `Bearer ${loggedIn.token}`);
+        const second = await request(server)
+          .post(`${route}/units/${unit.id}/completions`)
+          .set('authorization', `Bearer ${loggedIn.token}`);
 
-      expect(second.status).toBe(201);
-      expect(second.body.id).toBe(first.body.id);
-      expect(second.body.validatedAt).toBe(first.body.validatedAt);
-      expect(mailSpy).toHaveBeenCalledTimes(1);
+        expect(second.status).toBe(201);
+        expect(second.body.id).toBe(first.body.id);
+        expect(second.body.validatedAt).toBe(first.body.validatedAt);
+        expect(mailSpy).toHaveBeenCalledTimes(1);
 
-      const unitsResponse = await request(server)
-        .get(`${route}/units`)
-        .set('authorization', `Bearer ${loggedIn.token}`);
-      expect(unitsResponse.body[0].userCompletions).toHaveLength(1);
-
-      mailSpy.mockRestore();
+        const unitsResponse = await request(server)
+          .get(`${route}/units`)
+          .set('authorization', `Bearer ${loggedIn.token}`);
+        expect(unitsResponse.body[0].userCompletions).toHaveLength(1);
+      } finally {
+        mailSpy.mockRestore();
+      }
     });
 
     it('Should set elearningCompletedAt only when the last unit of the role is completed', async () => {

--- a/tests/elearning/elearning.e2e-spec.ts
+++ b/tests/elearning/elearning.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerStorage } from '@nestjs/throttler';
 import request from 'supertest';
 import * as uuid from 'uuid';
 import { MailsService } from 'src/mails/mails.service';
@@ -20,6 +21,7 @@ describe('Elearning', () => {
   let databaseHelper: DatabaseHelper;
   let usersHelper: UsersHelper;
   let elearningUnitFactory: ElearningUnitFactory;
+  let throttlerStorage: ThrottlerStorage;
 
   const route = '/elearning';
 
@@ -41,6 +43,7 @@ describe('Elearning', () => {
     usersHelper = moduleFixture.get<UsersHelper>(UsersHelper);
     elearningUnitFactory =
       moduleFixture.get<ElearningUnitFactory>(ElearningUnitFactory);
+    throttlerStorage = moduleFixture.get<ThrottlerStorage>(ThrottlerStorage);
   });
 
   afterAll(async () => {
@@ -54,6 +57,9 @@ describe('Elearning', () => {
 
   beforeEach(async () => {
     await databaseHelper.resetTestDB();
+    Object.keys(throttlerStorage.storage).forEach((key) => {
+      delete throttlerStorage.storage[key];
+    });
   });
 
   describe('GET /units', () => {
@@ -293,6 +299,45 @@ describe('Elearning', () => {
         .set('authorization', `Bearer ${loggedIn.token}`);
       expect(identity.status).toBe(200);
       expect(identity.body.elearningCompletedAt).not.toBeNull();
+    });
+
+    it('Should return 403 and create no completion when the unit does not belong to the user role', async () => {
+      const loggedIn = await usersHelper.createLoggedInUser({
+        role: UserRoles.CANDIDATE,
+      });
+
+      const coachUnit = await elearningUnitFactory.create(
+        { order: 1 },
+        { roles: [UserRoles.COACH] }
+      );
+
+      const response = await request(server)
+        .post(`${route}/units/${coachUnit.id}/completions`)
+        .set('authorization', `Bearer ${loggedIn.token}`);
+
+      expect(response.status).toBe(403);
+
+      const unitsResponse = await request(server)
+        .get(`${route}/units`)
+        .set('authorization', `Bearer ${loggedIn.token}`);
+      expect(unitsResponse.body[0].userCompletions).toHaveLength(0);
+    });
+
+    it('Should return 429 when the completion route is called past the throttle limit', async () => {
+      const loggedIn = await usersHelper.createLoggedInUser({
+        role: UserRoles.CANDIDATE,
+      });
+
+      const unit = await elearningUnitFactory.create({ order: 1 });
+
+      let lastResponse: request.Response;
+      for (let i = 0; i < 61; i += 1) {
+        lastResponse = await request(server)
+          .post(`${route}/units/${unit.id}/completions`)
+          .set('authorization', `Bearer ${loggedIn.token}`);
+      }
+
+      expect(lastResponse.status).toBe(429);
     });
   });
 });

--- a/tests/elearning/elearning.e2e-spec.ts
+++ b/tests/elearning/elearning.e2e-spec.ts
@@ -193,23 +193,39 @@ describe('Elearning', () => {
       expect(response.body.validatedAt).toBeTruthy();
     });
 
-    it('Should return 409 when completion already exists', async () => {
+    it('Should return the existing completion unchanged when replayed, without resending the congratulation mail', async () => {
       const loggedIn = await usersHelper.createLoggedInUser({
         role: UserRoles.CANDIDATE,
       });
 
       const unit = await elearningUnitFactory.create({ order: 1 });
 
+      const mailSpy = jest.spyOn(
+        MailsServiceMock.prototype,
+        'sendAllElearningUnitsCompletedMail'
+      );
+
       const first = await request(server)
         .post(`${route}/units/${unit.id}/completions`)
         .set('authorization', `Bearer ${loggedIn.token}`);
       expect(first.status).toBe(201);
+      expect(mailSpy).toHaveBeenCalledTimes(1);
 
       const second = await request(server)
         .post(`${route}/units/${unit.id}/completions`)
         .set('authorization', `Bearer ${loggedIn.token}`);
 
-      expect(second.status).toBe(409);
+      expect(second.status).toBe(201);
+      expect(second.body.id).toBe(first.body.id);
+      expect(second.body.validatedAt).toBe(first.body.validatedAt);
+      expect(mailSpy).toHaveBeenCalledTimes(1);
+
+      const unitsResponse = await request(server)
+        .get(`${route}/units`)
+        .set('authorization', `Bearer ${loggedIn.token}`);
+      expect(unitsResponse.body[0].userCompletions).toHaveLength(1);
+
+      mailSpy.mockRestore();
     });
 
     it('Should set elearningCompletedAt only when the last unit of the role is completed', async () => {
@@ -277,56 +293,6 @@ describe('Elearning', () => {
         .set('authorization', `Bearer ${loggedIn.token}`);
       expect(identity.status).toBe(200);
       expect(identity.body.elearningCompletedAt).not.toBeNull();
-    });
-  });
-
-  describe('DELETE /units/:unitId/completions', () => {
-    it('Should return 401 when not logged in', async () => {
-      const response = await request(server).delete(
-        `${route}/units/${uuid.v4()}/completions`
-      );
-      expect(response.status).toBe(401);
-    });
-
-    it('Should return 404 when completion does not exist', async () => {
-      const loggedIn = await usersHelper.createLoggedInUser({
-        role: UserRoles.CANDIDATE,
-      });
-
-      const unit = await elearningUnitFactory.create({ order: 1 });
-
-      const response = await request(server)
-        .delete(`${route}/units/${unit.id}/completions`)
-        .set('authorization', `Bearer ${loggedIn.token}`);
-
-      expect(response.status).toBe(404);
-    });
-
-    it('Should return 200 and delete an existing completion', async () => {
-      const loggedIn = await usersHelper.createLoggedInUser({
-        role: UserRoles.CANDIDATE,
-      });
-
-      const unit = await elearningUnitFactory.create({ order: 1 });
-
-      const createResponse = await request(server)
-        .post(`${route}/units/${unit.id}/completions`)
-        .set('authorization', `Bearer ${loggedIn.token}`);
-      expect(createResponse.status).toBe(201);
-
-      const deleteResponse = await request(server)
-        .delete(`${route}/units/${unit.id}/completions`)
-        .set('authorization', `Bearer ${loggedIn.token}`);
-
-      expect(deleteResponse.status).toBe(200);
-
-      const unitsResponse = await request(server)
-        .get(`${route}/units`)
-        .set('authorization', `Bearer ${loggedIn.token}`);
-
-      expect(unitsResponse.status).toBe(200);
-      expect(unitsResponse.body).toHaveLength(1);
-      expect(unitsResponse.body[0].userCompletions).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9327](https://entourage-asso.atlassian.net/browse/EN-9327)
**🚧 PR-Front :** [front/719](https://github.com/ReseauEntourage/entourage-job-front/pull/719)
**💬 Commentaire :**

This pull request refactors how e-learning completions are handled by removing the ability to delete completions and making the completion creation endpoint idempotent. Now, creating a completion for a unit that is already completed will simply return the existing completion instead of throwing an error. The tests and documentation are updated accordingly.

### API Changes

* Removed the `DELETE /units/:unitId/completions` endpoint and the associated controller and service logic for deleting e-learning completions. [[1]](diffhunk://#diff-9e0507485867a7402029215d4c65646923981c536a9fa704bf7b5e84091f1fdaL4) [[2]](diffhunk://#diff-9e0507485867a7402029215d4c65646923981c536a9fa704bf7b5e84091f1fdaL42-L50) [[3]](diffhunk://#diff-5fdd9c566ad35a9ba9ab7874c8b39fea03f40cad99f774e79d6e05735b9402faL105-L124) [[4]](diffhunk://#diff-8e9ea14d7354e7835c81d70d284b55658ffe526fb416e7699a2721adf03e7c0eL282-L331)

### Behavior Changes

* Changed the behavior of `createElearningCompletion` in `ElearningService` so that if a completion already exists, it is returned as-is instead of throwing a `ConflictException`. This makes the endpoint idempotent and avoids duplicate side effects. [[1]](diffhunk://#diff-5fdd9c566ad35a9ba9ab7874c8b39fea03f40cad99f774e79d6e05735b9402faL69-R69) [[2]](diffhunk://#diff-5fdd9c566ad35a9ba9ab7874c8b39fea03f40cad99f774e79d6e05735b9402faL88-R84)

### Tests

* Updated tests to verify that replaying a completion returns the existing completion and does not resend congratulation mails, and removed tests related to deleting completions. [[1]](diffhunk://#diff-8e9ea14d7354e7835c81d70d284b55658ffe526fb416e7699a2721adf03e7c0eL196-R228) [[2]](diffhunk://#diff-8e9ea14d7354e7835c81d70d284b55658ffe526fb416e7699a2721adf03e7c0eL282-L331)

### Documentation

* Updated method documentation in `ElearningService` to reflect the new idempotent behavior for creating completions.

### Code Cleanup

* Removed unused imports from `elearning.service.ts` as a result of the refactoring.

[EN-9327]: https://entourage-asso.atlassian.net/browse/EN-9327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ