### PR TITLE
Improve enterprise account management in Salesforce

### DIFF
--- a/src/companies/company-user.service.ts
+++ b/src/companies/company-user.service.ts
@@ -74,12 +74,16 @@ export class CompanyUsersService {
     updateInExternalDB = true
   ) {
     // If companyName is provided, find or create the company
+    // createInExternalDB is always false here: this method only ever links a non-admin coach
+    // (isAdmin is hardcoded to false below), so it must never trigger Salesforce Company account
+    // creation - the gated lookup/fallback logic in updateSalesforceUserCompany handles that instead
     let company: Company | null = null;
     if (companyName) {
       company = await this.companiesService.findOrCreateByName(
         companyName,
         user,
-        CompanyCreationContext.COACH_LINKING
+        CompanyCreationContext.COACH_LINKING,
+        false
       );
     }
 

--- a/src/external-services/salesforce/salesforce.service.ts
+++ b/src/external-services/salesforce/salesforce.service.ts
@@ -1269,7 +1269,7 @@ export class SalesforceService {
       contactSfId,
       {
         accountSfId,
-        companyName: companyName || undefined,
+        companyName,
       },
       determineContactRecordType(userToUpdate.role, isCompanyAdmin)
     );

--- a/src/external-services/salesforce/salesforce.service.ts
+++ b/src/external-services/salesforce/salesforce.service.ts
@@ -1211,16 +1211,21 @@ export class SalesforceService {
 
   /**
    * Link or unlink a Salesforce contact to a company account in Salesforce
-   * If companyId is null or company not found, link the contact to a household account instead
+   * Never creates or updates a Company account here - only an existing Company admin flow does that
+   * (via createOrUpdateSalesforceCompany). If hasAdmin is false, or the Company account can't be
+   * found in Salesforce despite hasAdmin being true, the contact falls back to a household account
    *
    * @param userId user's id in our database
    * @param companyName company name to link the user to in Salesforce, or null to unlink from any company
+   * @param isCompanyAdmin whether this specific user is the admin of the declared company (used for RecordType only)
+   * @param hasAdmin whether the declared company has any admin at all (gates Company account lookup)
    */
   async updateSalesforceUserCompany(
     userId: string,
     companyName: string | null,
-    isCompanyAdmin = false
-  ) {
+    isCompanyAdmin = false,
+    hasAdmin = false
+  ): Promise<{ companyAccountNotFound: boolean }> {
     this.setIsWorker(true);
 
     const userToUpdate = await this.findContactFromUserId(userId);
@@ -1231,22 +1236,27 @@ export class SalesforceService {
       throw new Error(`Contact not found in Salesforce for user ${userId}`);
     }
 
-    // Find the company in Salesforce if companyName is provided
-    let accountSfId = null;
-    if (companyName)
-      accountSfId = await this.createOrUpdateSalesforceCompany(companyName, {});
-
     const contactSfId = contactSf.Id;
 
-    // If no company found or companyName is null, unlink the contact from any company and link to household account
+    // Read-only lookup of the existing Company account: only when the declared company already has an admin
+    let accountSfId: string | null = null;
+    let companyAccountNotFound = false;
+    if (companyName && hasAdmin) {
+      const sfCompany = await this.findCompanyFromCompanyName(companyName);
+      if (sfCompany) {
+        accountSfId = sfCompany.Id;
+      } else {
+        companyAccountNotFound = true;
+      }
+    }
+
+    // No admin, no company declared, or Company account not found: fall back to a household account
     if (!accountSfId) {
-      // Create or find household account
-      const householdAccountId = await this.findOrCreateHouseholdAccount({
+      accountSfId = await this.findOrCreateHouseholdAccount({
         name: `${userToUpdate.firstName} ${userToUpdate.lastName} Foyer`,
         department: userToUpdate.department,
         address: getPostalCodeFromDepartment(userToUpdate.department),
       });
-      accountSfId = householdAccountId;
     }
 
     if (!accountSfId) {
@@ -1255,14 +1265,16 @@ export class SalesforceService {
       );
     }
 
-    // Link the contact to the new company or unlink if companyId is null
     await this.updateContact(
       contactSfId,
       {
         accountSfId,
+        companyName: companyName || undefined,
       },
       determineContactRecordType(userToUpdate.role, isCompanyAdmin)
     );
+
+    return { companyAccountNotFound };
   }
 
   async createOrUpdateCompanySalesforceLead(lead: CompanyLeadProps) {

--- a/src/external-services/salesforce/salesforce.types.ts
+++ b/src/external-services/salesforce/salesforce.types.ts
@@ -422,7 +422,7 @@ export interface ContactProps {
   accountSfId?: string;
   birthDate?: Date;
   casquettes?: Casquette[];
-  companyName?: string;
+  companyName?: string | null;
   department?: Department;
   email?: string;
   firstName?: string;
@@ -459,7 +459,7 @@ export interface SalesforceContact {
   Nationalit__c: string;
   Phone: string;
   Plus_haut_niveau_de_formation_attein__c: string;
-  Raison_social_Entreprise__c?: string;
+  Raison_social_Entreprise__c?: string | null;
   RecordTypeId: ContactRecordType;
   Reseaux__c: 'LinkedOut';
   Situation_d_h_bergement__c: string;

--- a/src/external-services/salesforce/salesforce.types.ts
+++ b/src/external-services/salesforce/salesforce.types.ts
@@ -422,6 +422,7 @@ export interface ContactProps {
   accountSfId?: string;
   birthDate?: Date;
   casquettes?: Casquette[];
+  companyName?: string;
   department?: Department;
   email?: string;
   firstName?: string;
@@ -458,6 +459,7 @@ export interface SalesforceContact {
   Nationalit__c: string;
   Phone: string;
   Plus_haut_niveau_de_formation_attein__c: string;
+  Raison_social_Entreprise__c?: string;
   RecordTypeId: ContactRecordType;
   Reseaux__c: 'LinkedOut';
   Situation_d_h_bergement__c: string;

--- a/src/external-services/salesforce/salesforce.utils.ts
+++ b/src/external-services/salesforce/salesforce.utils.ts
@@ -483,6 +483,7 @@ export const mapSalesforceContactFields = (
     jobSearchDuration,
     gender,
     refererId,
+    companyName,
   }: ContactProps,
   recordType: ContactRecordType
 ): SalesforceContact => {
@@ -525,6 +526,7 @@ export const mapSalesforceContactFields = (
       : undefined,
     ID_App_Entourage_Pro__c: id || undefined,
     Source__c: 'Lead entrant',
+    Raison_social_Entreprise__c: companyName || undefined,
     ...socialSituationFields,
     Genre__c: gender
       ? formatSalesforceValue<CandidateGender>(gender, LeadGender)

--- a/src/external-services/salesforce/salesforce.utils.ts
+++ b/src/external-services/salesforce/salesforce.utils.ts
@@ -526,7 +526,7 @@ export const mapSalesforceContactFields = (
       : undefined,
     ID_App_Entourage_Pro__c: id || undefined,
     Source__c: 'Lead entrant',
-    Raison_social_Entreprise__c: companyName || undefined,
+    Raison_social_Entreprise__c: companyName ?? null,
     ...socialSituationFields,
     Genre__c: gender
       ? formatSalesforceValue<CandidateGender>(gender, LeadGender)

--- a/src/queues/consumers/work-queue.processor.ts
+++ b/src/queues/consumers/work-queue.processor.ts
@@ -149,7 +149,11 @@ export class WorkQueueProcessor extends WorkerHost {
 
   /**
    * Create or update a user in Salesforce
-   * If companyId is provided, also create or update the company in Salesforce through a separate job (CREATE_OR_UPDATE_SALESFORCE_COMPANY)
+   * If companyId is provided:
+   * - and the user is the company admin (creating it), create or update the Company account
+   *   through a separate job (CREATE_OR_UPDATE_SALESFORCE_COMPANY), unchanged
+   * - otherwise, enqueue UPDATE_SALESFORCE_USER_COMPANY directly so the coach goes through the
+   *   same gated Company account lookup/fallback logic as `PUT /user/company`
    * @param job - Job containing user data to create or update in Salesforce
    * @returns A message indicating the result of the operation
    */
@@ -177,14 +181,20 @@ export class WorkQueueProcessor extends WorkerHost {
         // The "Position" field in Salesforce corresponds to the user's role in the company
         position: data.companyRole,
       });
-      // If companyId is provided, create or update the company in Salesforce
       if (data.companyId) {
-        const company = await this.companiesService.findOne(data.companyId);
-        if (!company) throw new Error('Company not found');
-        await this.workQueue.add(Jobs.CREATE_OR_UPDATE_SALESFORCE_COMPANY, {
-          name: company.name,
-          userId: data.userId,
-        });
+        if (data.isCompanyAdmin) {
+          const company = await this.companiesService.findOne(data.companyId);
+          if (!company) throw new Error('Company not found');
+          await this.workQueue.add(Jobs.CREATE_OR_UPDATE_SALESFORCE_COMPANY, {
+            name: company.name,
+            userId: data.userId,
+          });
+        } else {
+          await this.workQueue.add(Jobs.UPDATE_SALESFORCE_USER_COMPANY, {
+            userId: data.userId,
+            companyId: data.companyId,
+          });
+        }
       }
       return `Salesforce : created or updated user '${data.userId}'`;
     }
@@ -224,6 +234,8 @@ export class WorkQueueProcessor extends WorkerHost {
 
   /**
    * Update a user's company in Salesforce
+   * If data.companyId is null (coach removing their company), this is a nominal case that falls back
+   * to a household account - it does not throw
    * @param job - Job containing userId and companyId to update the user's company in Salesforce
    * @returns A message indicating the result of the operation
    */
@@ -232,15 +244,30 @@ export class WorkQueueProcessor extends WorkerHost {
   ) {
     const { data } = job;
     if (process.env.ENABLE_SF === 'true') {
-      const company = await this.companiesService.findOne(data.companyId);
-      if (!company) throw new Error('Company not found');
-      const isAdmin = company.admin && company.admin.id === data.userId;
+      const company = data.companyId
+        ? await this.companiesService.findOne(data.companyId)
+        : null;
+      if (data.companyId && !company) throw new Error('Company not found');
 
-      await this.salesforceService.updateSalesforceUserCompany(
-        data.userId,
-        company ? company.name : null,
-        isAdmin
-      );
+      // hasAdmin: does the declared company have any admin at all (gates Company account lookup)
+      const hasAdmin = company?.admin != null;
+      // isThisUserTheAdmin: is this specific user the admin (only affects Contact RecordType)
+      const isThisUserTheAdmin = company?.admin?.id === data.userId;
+
+      const { companyAccountNotFound } =
+        await this.salesforceService.updateSalesforceUserCompany(
+          data.userId,
+          company ? company.name : null,
+          isThisUserTheAdmin,
+          hasAdmin
+        );
+
+      if (companyAccountNotFound) {
+        this.logger.warn(
+          `Salesforce Company account not found for company '${company?.name}' (id ${data.companyId}) despite an existing admin - user '${data.userId}' falls back to household account`
+        );
+      }
+
       return `Salesforce : updated user '${data.userId}' company to '${data.companyId}'`;
     }
     return `Salesforce job ignored : update of user '${data.userId}' company to '${data.companyId}'`;


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9258](https://entourage-asso.atlassian.net/browse/EN-9258)
**💬 Commentaire :**

This pull request refactors and improves how user-company relationships are managed in Salesforce, especially when linking or unlinking users to company accounts. The changes ensure that company accounts are only created or updated by admins, and that fallback to household accounts is handled more robustly. The update also introduces better logging and clearer job handling in the work queue processor.

**Salesforce user-company linking logic:**

* The `updateSalesforceUserCompany` method now only links a user to an existing Company account if the company already has an admin; otherwise, the user is linked to a household account. The method now returns a status indicating if the company account was not found. [[1]](diffhunk://#diff-3f6c9087780f82e0ec45bd1b5cd2a316c2cb707572da1bd578e5ccedf97f775bL1214-R1228) [[2]](diffhunk://#diff-3f6c9087780f82e0ec45bd1b5cd2a316c2cb707572da1bd578e5ccedf97f775bL1234-L1249) [[3]](diffhunk://#diff-3f6c9087780f82e0ec45bd1b5cd2a316c2cb707572da1bd578e5ccedf97f775bL1258-R1277)
* The Salesforce contact mapping now includes the company name (`companyName`) and maps it to the Salesforce field `Raison_social_Entreprise__c`. [[1]](diffhunk://#diff-1d140d9a0f44bcceb90f283565045ef72068877ddb4f17dfd95129de0863a525R425) [[2]](diffhunk://#diff-1d140d9a0f44bcceb90f283565045ef72068877ddb4f17dfd95129de0863a525R462) [[3]](diffhunk://#diff-a261270cf124e6181dd77cff56325bbc156b3ee761b0439e7316244a372264afR486) [[4]](diffhunk://#diff-a261270cf124e6181dd77cff56325bbc156b3ee761b0439e7316244a372264afR529)

**Work queue and job handling improvements:**

* The work queue processor now distinguishes between admin and non-admin users when handling company updates: admins trigger a company account creation/update job, while non-admins or company removals trigger a direct user-company update with proper fallback logic. [[1]](diffhunk://#diff-6235fb5e5593be46608e5be161e167e20eef68900baacc7f46961ea3432f93f3L152-R156) [[2]](diffhunk://#diff-6235fb5e5593be46608e5be161e167e20eef68900baacc7f46961ea3432f93f3L180-R197) [[3]](diffhunk://#diff-6235fb5e5593be46608e5be161e167e20eef68900baacc7f46961ea3432f93f3R237-R238)
* When updating a user's company, the processor checks if the company exists, determines admin status, and logs a warning if a company account is missing in Salesforce despite an admin being present.

These changes make the Salesforce integration safer, more predictable, and easier to debug.

[EN-9258]: https://entourage-asso.atlassian.net/browse/EN-9258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ