### PR TITLE
Enhance SMS error logging and streamline unanswered conversation handling

### DIFF
--- a/src/external-services/vonage/vonage.service.ts
+++ b/src/external-services/vonage/vonage.service.ts
@@ -36,7 +36,22 @@ export class VonageService {
         `SMS sent successfully to ${normalizedTo} (uuid: ${messageUUID})`
       );
     } catch (error) {
-      this.logger.error(`Failed to send SMS to ${normalizedTo}`, error);
+      const errorCode = (error as { code?: string })?.code;
+      const errorStatus = (error as { response?: { status?: number } })
+        ?.response?.status;
+      const errorMessage = error instanceof Error ? error.message : undefined;
+
+      if (errorCode || errorStatus || errorMessage) {
+        this.logger.error(`Failed to send SMS to ${normalizedTo}`, {
+          to: normalizedTo,
+          errorCode,
+          errorStatus,
+          errorMessage,
+        });
+      } else {
+        this.logger.error(`Failed to send SMS to ${normalizedTo}`, error);
+      }
+
       throw error;
     }
   }

--- a/src/external-services/vonage/vonage.service.ts
+++ b/src/external-services/vonage/vonage.service.ts
@@ -42,12 +42,14 @@ export class VonageService {
       const errorMessage = error instanceof Error ? error.message : undefined;
 
       if (errorCode || errorStatus || errorMessage) {
-        this.logger.error(`Failed to send SMS to ${normalizedTo}`, {
-          to: normalizedTo,
-          errorCode,
-          errorStatus,
-          errorMessage,
-        });
+        this.logger.error(
+          `Failed to send SMS to ${normalizedTo} (errorCode=${
+            errorCode ?? 'n/a'
+          }, errorStatus=${errorStatus ?? 'n/a'}, errorMessage=${
+            errorMessage ?? 'n/a'
+          })`,
+          error
+        );
       } else {
         this.logger.error(`Failed to send SMS to ${normalizedTo}`, error);
       }

--- a/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
+++ b/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
@@ -15,7 +15,7 @@ import { UserProfileRecommendationsService } from 'src/user-profile-recommendati
 import { UserProfilesService } from 'src/user-profiles/user-profiles.service';
 import { User } from 'src/users/models';
 import { UsersService } from 'src/users/users.service';
-import { UserRoles } from 'src/users/users.types';
+import { NormalUserRole, UserRoles } from 'src/users/users.types';
 import { UsersDeletionService } from 'src/users-deletion/users-deletion.service';
 import { getZoneNameFromDepartment } from 'src/utils/misc';
 
@@ -1516,39 +1516,78 @@ export class CronTasksProcessor extends WorkerHost {
 
   async prepareUnansweredConversationsSms() {
     const DAYS_SINCE_LAST_CONNECTION = 3;
+    const recipientRoles: NormalUserRole[] = [
+      UserRoles.CANDIDATE,
+      UserRoles.COACH,
+    ];
 
-    this.logger.log(
-      `Preparing unanswered conversations SMS for candidates (first message sent ${DAYS_SINCE_LAST_CONNECTION} days ago)...`
+    const summaries = await Promise.all(
+      recipientRoles.map((recipientRole) =>
+        this.sendUnansweredConversationsSmsForRole(
+          recipientRole,
+          DAYS_SINCE_LAST_CONNECTION
+        )
+      )
     );
 
-    const rows =
-      await this.usersService.getCandidateRowsForUnansweredConversationSms(
-        DAYS_SINCE_LAST_CONNECTION
+    const failedSummaries = summaries.filter((summary) => !summary.succeeded);
+
+    if (failedSummaries.length > 0) {
+      throw new Error(
+        failedSummaries
+          .map(
+            (summary) =>
+              `Failed sending ${summary.failureCount}/${summary.total} unanswered conversation SMS to ${summary.recipientRole}`
+          )
+          .join('; ')
       );
+    }
+
+    return summaries
+      .map(
+        (summary) =>
+          `Sent ${summary.successCount} unanswered conversation SMS to ${summary.recipientRole}`
+      )
+      .join(', ');
+  }
+
+  private async sendUnansweredConversationsSmsForRole(
+    recipientRole: NormalUserRole,
+    daysSinceFirstMessage: number
+  ) {
+    this.logger.log(
+      `Preparing unanswered conversations SMS for ${recipientRole} (first message sent ${daysSinceFirstMessage} days ago)...`
+    );
+
+    const rows = await this.usersService.getUnansweredConversationSmsRows(
+      recipientRole,
+      daysSinceFirstMessage
+    );
 
     this.logger.log(
-      `Found ${rows.length} candidates with unanswered conversations to notify via SMS`
+      `Found ${rows.length} ${recipientRole} with unanswered conversations to notify via SMS`
     );
 
     const results = await Promise.allSettled(
       rows.map(async (row) => {
         this.logger.log(
-          `Sending SMS to candidate ${row.candidateId} for conversation ${row.conversationId} with coach ${row.coachId}`
+          `Sending SMS to ${recipientRole} ${row.recipientId} for conversation ${row.conversationId} with ${row.senderId}`
         );
-        return this.usersService.sendCandidateUnansweredConversationSms(
-          row.candidatePhone,
-          row.coachFirstName,
-          row.coachId
+        return this.usersService.sendUnansweredConversationSms(
+          row.recipientPhone,
+          recipientRole,
+          row.senderFirstName,
+          row.senderId
         );
       })
     );
 
     const { succeeded, successIds, failures } = collectSettledResults(
-      rows.map((row) => ({ id: row.candidateId })),
+      rows.map((row) => ({ id: row.recipientId })),
       results,
-      (candidateId, reason) => {
+      (recipientId, reason) => {
         this.logger.error(
-          `Failed sending SMS to candidate ${candidateId}`,
+          `Failed sending SMS to ${recipientRole} ${recipientId}`,
           reason
         );
       }
@@ -1556,7 +1595,7 @@ export class CronTasksProcessor extends WorkerHost {
 
     await this.cronTasksSlackReporterService.sendCronTaskResultToSlack(
       succeeded,
-      `📱 SMS conversations non répondues - J+${DAYS_SINCE_LAST_CONNECTION}`,
+      `📱 SMS conversations non répondues (${recipientRole}) - J+${daysSinceFirstMessage}`,
       {
         total: rows.length,
         success: successIds.length,
@@ -1565,13 +1604,13 @@ export class CronTasksProcessor extends WorkerHost {
       failures
     );
 
-    if (!succeeded) {
-      throw new Error(
-        `Failed sending ${failures.length}/${rows.length} unanswered conversation SMS`
-      );
-    }
-
-    return `Sent ${successIds.length} unanswered conversation SMS`;
+    return {
+      recipientRole,
+      total: rows.length,
+      successCount: successIds.length,
+      failureCount: failures.length,
+      succeeded,
+    };
   }
 
   private async prepareLinkedInShareProfileMails() {

--- a/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
+++ b/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
@@ -11,6 +11,7 @@ import {
 } from 'src/queues/consumers/cron-tasks/cron-tasks.utils';
 import { Jobs, Queues } from 'src/queues/queues.types';
 import { RecruitementAlertsService } from 'src/recruitement-alerts/recruitement-alerts.service';
+import { tracer } from 'src/tracer';
 import { UserProfileRecommendationsService } from 'src/user-profile-recommendations/user-profile-recommendations-ai.service';
 import { UserProfilesService } from 'src/user-profiles/user-profiles.service';
 import { User } from 'src/users/models';
@@ -1515,7 +1516,7 @@ export class CronTasksProcessor extends WorkerHost {
   }
 
   async prepareUnansweredConversationsSms() {
-    const DAYS_SINCE_LAST_CONNECTION = 3;
+    const DAYS_SINCE_FIRST_MESSAGE = 3;
     const recipientRoles: NormalUserRole[] = [
       UserRoles.CANDIDATE,
       UserRoles.COACH,
@@ -1525,10 +1526,12 @@ export class CronTasksProcessor extends WorkerHost {
       recipientRoles.map((recipientRole) =>
         this.sendUnansweredConversationsSmsForRole(
           recipientRole,
-          DAYS_SINCE_LAST_CONNECTION
+          DAYS_SINCE_FIRST_MESSAGE
         )
       )
     );
+
+    tracer.dogstatsd.flush();
 
     const failedSummaries = summaries.filter((summary) => !summary.succeeded);
 

--- a/src/sms/sms.service.ts
+++ b/src/sms/sms.service.ts
@@ -2,6 +2,18 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ShortioService } from 'src/external-services/shortio/shortio.service';
 import { QueuesService } from 'src/queues/producers/queues.service';
 import { Jobs } from 'src/queues/queues.types';
+import { tracer } from 'src/tracer';
+import { NormalUserRole, UserRoles } from 'src/users/users.types';
+
+const SENDER_ROLE_BY_RECIPIENT: Record<NormalUserRole, NormalUserRole> = {
+  [UserRoles.CANDIDATE]: UserRoles.COACH,
+  [UserRoles.COACH]: UserRoles.CANDIDATE,
+};
+
+const METRIC_ROLE_TAG: Record<NormalUserRole, string> = {
+  [UserRoles.CANDIDATE]: 'candidate',
+  [UserRoles.COACH]: 'coach',
+};
 
 @Injectable()
 export class SmsService {
@@ -12,22 +24,29 @@ export class SmsService {
     private readonly shortioService: ShortioService
   ) {}
 
-  async sendCandidateUnansweredConversationSms(
-    candidatePhone: string,
-    coachFirstName: string,
-    coachId: string
+  async sendUnansweredConversationSms(
+    recipientPhone: string,
+    recipientRole: NormalUserRole,
+    senderFirstName: string,
+    senderId: string
   ) {
-    const conversationUrl = `${process.env.FRONT_URL}/backoffice/messaging?userId=${coachId}`;
+    const senderRole = SENDER_ROLE_BY_RECIPIENT[recipientRole];
+    const conversationUrl = `${process.env.FRONT_URL}/backoffice/messaging?userId=${senderId}`;
     const shortUrl = await this.shortioService.shortenUrl(conversationUrl);
-    const text = `${coachFirstName}, Coach sur Entourage Pro, vous a envoyé un message. Répondre à son message : ${shortUrl}`;
+    const text = `${senderFirstName}, ${senderRole} sur Entourage Pro, vous a envoyé un message. Répondre à son message : ${shortUrl}`;
 
     this.logger.log('Shortened conversation URL for SMS: ' + shortUrl);
     this.logger.log(
-      `Queuing SMS to candidate for conversation with coach ${coachId}`
+      `Queuing unanswered conversation reminder SMS to ${recipientRole} for conversation with ${senderRole} ${senderId}`
     );
 
+    tracer.dogstatsd.increment('sms.reminder.sent', 1, {
+      role: METRIC_ROLE_TAG[recipientRole],
+    });
+    tracer.dogstatsd.flush();
+
     return this.queuesService.addToWorkQueue(Jobs.SEND_SMS, {
-      to: candidatePhone,
+      to: recipientPhone,
       text,
     });
   }

--- a/src/sms/sms.service.ts
+++ b/src/sms/sms.service.ts
@@ -40,14 +40,15 @@ export class SmsService {
       `Queuing unanswered conversation reminder SMS to ${recipientRole} for conversation with ${senderRole} ${senderId}`
     );
 
-    tracer.dogstatsd.increment('sms.reminder.sent', 1, {
-      role: METRIC_ROLE_TAG[recipientRole],
-    });
-    tracer.dogstatsd.flush();
-
-    return this.queuesService.addToWorkQueue(Jobs.SEND_SMS, {
+    const result = await this.queuesService.addToWorkQueue(Jobs.SEND_SMS, {
       to: recipientPhone,
       text,
     });
+
+    tracer.dogstatsd.increment('sms.reminder.sent', 1, {
+      role: METRIC_ROLE_TAG[recipientRole],
+    });
+
+    return result;
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -45,6 +45,7 @@ import {
 } from './models/user.include';
 import {
   MemberFilterKey,
+  NormalUserRole,
   OnboardingStatus,
   UserRole,
   UserRoles,
@@ -1350,24 +1351,30 @@ export class UsersService {
     );
   }
 
-  async getCandidateRowsForUnansweredConversationSms(
+  async getUnansweredConversationSmsRows(
+    recipientRole: NormalUserRole,
     daysSinceFirstMessage: number
   ): Promise<
     {
-      candidateId: string;
-      candidatePhone: string;
-      coachFirstName: string;
-      coachId: string;
+      recipientId: string;
+      recipientPhone: string;
+      senderFirstName: string;
+      senderId: string;
       conversationId: string;
     }[]
   > {
+    const senderRole =
+      recipientRole === UserRoles.CANDIDATE
+        ? UserRoles.COACH
+        : UserRoles.CANDIDATE;
+
     return this.userModel.sequelize.query(
       `
       SELECT
-        candidate.id           AS "candidateId",
-        candidate.phone        AS "candidatePhone",
-        coach."firstName"      AS "coachFirstName",
-        coach.id               AS "coachId",
+        recipient.id           AS "recipientId",
+        recipient.phone        AS "recipientPhone",
+        sender."firstName"     AS "senderFirstName",
+        sender.id              AS "senderId",
         c.id                   AS "conversationId"
       FROM "Conversations" c
       JOIN (
@@ -1378,26 +1385,26 @@ export class UsersService {
         FROM "Messages"
         ORDER BY "conversationId", "createdAt" ASC
       ) first_msg ON first_msg."conversationId" = c.id
-      JOIN "Users" coach
-        ON coach.id = first_msg."senderId"
-        AND coach.role = 'Coach'
-        AND coach."deletedAt" IS NULL
-      JOIN "ConversationParticipants" cp_candidate
-        ON cp_candidate."conversationId" = c.id
-        AND cp_candidate."userId" != first_msg."senderId"
-      JOIN "Users" candidate
-        ON candidate.id = cp_candidate."userId"
-        AND candidate.role = 'Candidat'
-        AND candidate."deletedAt" IS NULL
-        AND candidate.phone IS NOT NULL
-        AND candidate.phone != ''
+      JOIN "Users" sender
+        ON sender.id = first_msg."senderId"
+        AND sender.role = '${senderRole}'
+        AND sender."deletedAt" IS NULL
+      JOIN "ConversationParticipants" cp_recipient
+        ON cp_recipient."conversationId" = c.id
+        AND cp_recipient."userId" != first_msg."senderId"
+      JOIN "Users" recipient
+        ON recipient.id = cp_recipient."userId"
+        AND recipient.role = '${recipientRole}'
+        AND recipient."deletedAt" IS NULL
+        AND recipient.phone IS NOT NULL
+        AND recipient.phone != ''
       WHERE
         c.type = '${ConversationType.DIRECT}'
         AND DATE(first_msg."firstMessageAt") = CURRENT_DATE - INTERVAL '${daysSinceFirstMessage} days'
         AND NOT EXISTS (
           SELECT 1 FROM "Messages" m
           WHERE m."conversationId" = c.id
-            AND m."authorId" = candidate.id
+            AND m."authorId" = recipient.id
         )
       `,
       { type: QueryTypes.SELECT, raw: true }
@@ -1665,15 +1672,17 @@ export class UsersService {
     );
   }
 
-  async sendCandidateUnansweredConversationSms(
-    candidatePhone: string,
-    coachFirstName: string,
-    coachId: string
+  async sendUnansweredConversationSms(
+    recipientPhone: string,
+    recipientRole: NormalUserRole,
+    senderFirstName: string,
+    senderId: string
   ) {
-    return this.smsService.sendCandidateUnansweredConversationSms(
-      candidatePhone,
-      coachFirstName,
-      coachId
+    return this.smsService.sendUnansweredConversationSms(
+      recipientPhone,
+      recipientRole,
+      senderFirstName,
+      senderId
     );
   }
 


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9386](https://entourage-asso.atlassian.net/browse/EN-9386)
**💬 Commentaire :**

This pull request refactors and generalizes the logic for sending unanswered conversation SMS reminders, extending support to both candidates and coaches (previously only candidates were supported). It introduces role-based handling throughout the workflow, improves error handling and logging, and updates the database queries and SMS content to be role-agnostic.

**Role-based unanswered conversation SMS reminders:**

* The unanswered conversation SMS workflow is now generalized to support both candidates and coaches, using the new `NormalUserRole` type and role-based logic throughout the codebase. [[1]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7R1519-R1598) [[2]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7L1568-R1613) [[3]](diffhunk://#diff-3c0c327c2b8b0a19936dc163ae4f1afb15e6310cdf373cd5304e1a061a2dbf24R5-R16) [[4]](diffhunk://#diff-3c0c327c2b8b0a19936dc163ae4f1afb15e6310cdf373cd5304e1a061a2dbf24L15-R49) [[5]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L1353-R1377) [[6]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L1381-R1407) [[7]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L1668-R1685)

**Database query and service updates:**

* The database query and related service methods have been updated to select sender/recipient dynamically based on role, replacing candidate/coach-specific logic with role-agnostic identifiers. [[1]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L1353-R1377) [[2]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L1381-R1407)

**Improved error handling and logging:**

* Enhanced error logging in `VonageService` to include error codes, statuses, and messages for better observability when SMS sending fails.
* The SMS sending summary now aggregates results by role and throws a descriptive error if any SMS batch fails, improving operational visibility. [[1]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7R1519-R1598) [[2]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7L1568-R1613)

**SMS content and metrics:**

* SMS content and logging now dynamically reference sender/recipient roles, and a Datadog metric is incremented with the recipient's role for monitoring.

**Type and import updates:**

* Updated imports and types across files to use `NormalUserRole` and ensure type safety for role-based logic. [[1]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7L18-R18) [[2]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577R48)

These changes make the unanswered conversation SMS feature more flexible, maintainable, and observable.

[EN-9386]: https://entourage-asso.atlassian.net/browse/EN-9386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ