### PR TITLE
Refactor recommendation mail preparation and user eligibility checks

### DIFF
--- a/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
+++ b/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
@@ -498,14 +498,9 @@ export class CronTasksProcessor extends WorkerHost {
   }
 
   async prepareRecommendationMails() {
-    const DAYS_TO_CONTACT = [10, 20, 30];
     const BATCH_SIZE = 3; // Process in small batches to limit concurrent calls
 
-    this.logger.log(
-      `Preparing recommendation mails for users inactive since ${DAYS_TO_CONTACT.join(
-        ', '
-      )} days...`
-    );
+    this.logger.log('Preparing recommendation mails...');
 
     let totalUsers = 0;
     let totalSuccess = 0;
@@ -513,81 +508,77 @@ export class CronTasksProcessor extends WorkerHost {
     let totalFailures = 0;
     const skippedUserIds: string[] = [];
 
-    for (const days of DAYS_TO_CONTACT) {
-      this.logger.log(
-        `Fetching users inactive for ${days} days for recommendation mail...`
+    const users =
+      await this.usersService.getUsersInactiveForRecommendationMails();
+
+    this.logger.log(
+      `Found ${users.length} users eligible for recommendation mail`
+    );
+
+    for (const batch of chunk(users, BATCH_SIZE)) {
+      const batchResults = await Promise.allSettled(
+        batch.map(async (user) => {
+          totalUsers++;
+
+          const userWithRelations =
+            await this.usersService.findOneWithRelations(user.id);
+
+          const userProfile = await this.userProfilesService.findOneByUserId(
+            user.id
+          );
+
+          if (!userWithRelations || !userProfile) {
+            totalNotEnoughReco++;
+            this.logger.log(
+              `Skipping user ${user.id}: missing data (${
+                !userWithRelations ? 'user with relations' : ''
+              }${!userWithRelations && !userProfile ? ' & ' : ''}${
+                !userProfile ? 'user profile' : ''
+              })`
+            );
+            return;
+          }
+
+          const userRecommendations =
+            await this.userProfileRecommendationsService.retrieveOrComputeRecommendationsForUserIdIA(
+              userWithRelations,
+              userProfile,
+              3
+            );
+
+          if (userRecommendations.length < 3) {
+            totalNotEnoughReco++;
+            skippedUserIds.push(user.id);
+            this.logger.log(
+              `Skipping user ${user.id}: only ${userRecommendations.length} recommendations found (need 3)`
+            );
+            return;
+          }
+
+          await this.usersService.sendRecommendationsMail(
+            userWithRelations,
+            userRecommendations
+          );
+          totalSuccess++;
+        })
       );
 
-      const users =
-        await this.usersService.getUsersInactiveForRecommendationMails(days);
-
-      this.logger.log(`Found ${users.length} users inactive for ${days} days`);
-
-      for (const batch of chunk(users, BATCH_SIZE)) {
-        const batchResults = await Promise.allSettled(
-          batch.map(async (user) => {
-            totalUsers++;
-
-            const userWithRelations =
-              await this.usersService.findOneWithRelations(user.id);
-
-            const userProfile = await this.userProfilesService.findOneByUserId(
-              user.id
-            );
-
-            if (!userWithRelations || !userProfile) {
-              totalNotEnoughReco++;
-              this.logger.log(
-                `Skipping user ${user.id}: missing data (${
-                  !userWithRelations ? 'user with relations' : ''
-                }${!userWithRelations && !userProfile ? ' & ' : ''}${
-                  !userProfile ? 'user profile' : ''
-                })`
-              );
-              return;
-            }
-
-            const userRecommendations =
-              await this.userProfileRecommendationsService.retrieveOrComputeRecommendationsForUserIdIA(
-                userWithRelations,
-                userProfile,
-                3
-              );
-
-            if (userRecommendations.length < 3) {
-              totalNotEnoughReco++;
-              skippedUserIds.push(user.id);
-              this.logger.log(
-                `Skipping user ${user.id}: only ${userRecommendations.length} recommendations found (need 3)`
-              );
-              return;
-            }
-
-            await this.usersService.sendRecommendationsMail(
-              userWithRelations,
-              userRecommendations
-            );
-            totalSuccess++;
-          })
-        );
-
-        batchResults.forEach((result, index) => {
-          if (result.status === 'rejected') {
-            totalFailures++;
-            this.logger.error(
-              `Failed preparing recommendation mail for user ${batch[index]?.id}`,
-              result.reason
-            );
-          }
-        });
-      }
+      batchResults.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          totalFailures++;
+          this.logger.error(
+            `Failed preparing recommendation mail for user ${batch[index]?.id}`,
+            result.reason
+          );
+        }
+      });
     }
 
     const succeeded = totalFailures === 0;
 
     await this.cronTasksSlackReporterService.sendCronTaskResultToSlack(
       succeeded,
-      `👬 Users recommendation emails - J+${DAYS_TO_CONTACT.join('/')}`,
+      '👬 Users recommendation emails',
       {
         total: totalUsers,
         success: totalSuccess,

--- a/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
+++ b/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
@@ -507,9 +507,10 @@ export class CronTasksProcessor extends WorkerHost {
     let totalNotEnoughReco = 0;
     let totalFailures = 0;
     const skippedUserIds: string[] = [];
+    const failures: SettledFailure[] = [];
 
     const users =
-      await this.usersService.getUsersInactiveForRecommendationMails();
+      await this.usersService.getUsersEligibleForRecommendationMails();
 
     this.logger.log(
       `Found ${users.length} users eligible for recommendation mail`
@@ -566,8 +567,10 @@ export class CronTasksProcessor extends WorkerHost {
       batchResults.forEach((result, index) => {
         if (result.status === 'rejected') {
           totalFailures++;
+          const itemId = batch[index]?.id ?? `unknown-${index}`;
+          failures.push({ itemId, reason: result.reason });
           this.logger.error(
-            `Failed preparing recommendation mail for user ${batch[index]?.id}`,
+            `Failed preparing recommendation mail for user ${itemId}`,
             result.reason
           );
         }
@@ -584,7 +587,7 @@ export class CronTasksProcessor extends WorkerHost {
         success: totalSuccess,
         failure: totalFailures + totalNotEnoughReco,
       },
-      [],
+      failures,
       skippedUserIds
     );
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1025,9 +1025,9 @@ export class UsersService {
    * server's local date (the cron runs daily at noon, so this stays stable
    * across a single day).
    */
-  async getUsersInactiveForRecommendationMails(
+  async getUsersEligibleForRecommendationMails(
     intervalDays: number = RECOMMENDATION_MAILS_INTERVAL_DAYS
-  ): Promise<Pick<User, 'id' | 'firstName' | 'email' | 'role' | 'zone'>[]> {
+  ): Promise<Pick<User, 'id'>[]> {
     // Truncated to the cron server's local date (not the DB server's), so the
     // modulo stays stable across a single day regardless of the exact time
     // onboarding was completed.

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -57,6 +57,7 @@ import {
 } from './users.utils';
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const RECOMMENDATION_MAILS_INTERVAL_DAYS = 10;
 
 export type NoResponseToFirstMessageResultDto = {
   addressees: User[];
@@ -1018,16 +1019,19 @@ export class UsersService {
     });
   }
 
+  /**
+   * Users are eligible every `intervalDays` days after `onboardingCompletedAt`,
+   * regardless of connection activity. Day comparisons are truncated to the
+   * server's local date (the cron runs daily at noon, so this stays stable
+   * across a single day).
+   */
   async getUsersInactiveForRecommendationMails(
-    daysSinceLastConnection: number
+    intervalDays: number = RECOMMENDATION_MAILS_INTERVAL_DAYS
   ): Promise<Pick<User, 'id' | 'firstName' | 'email' | 'role' | 'zone'>[]> {
-    const startDate = new Date(
-      new Date().setHours(0, 0, 0, 0) - daysSinceLastConnection * DAY_IN_MS
-    );
-    const endDate = new Date(
-      new Date().setHours(0, 0, 0, 0) -
-        (daysSinceLastConnection - 1) * DAY_IN_MS
-    );
+    // Truncated to the cron server's local date (not the DB server's), so the
+    // modulo stays stable across a single day regardless of the exact time
+    // onboarding was completed.
+    const today = new Date(new Date().setHours(0, 0, 0, 0));
 
     return this.userModel.sequelize.query(
       `
@@ -1037,9 +1041,11 @@ export class UsersService {
       JOIN "UserProfiles" up ON u.id = up."userId"
       WHERE
         up."isAvailable" IS TRUE
-        AND u."lastConnection" >= :startDate
-        AND u."lastConnection" < :endDate
+        AND up."optInRecommendations" IS TRUE
         AND u."onboardingStatus" = :onboardingStatus
+        AND u."onboardingCompletedAt" IS NOT NULL
+        AND (:today::timestamptz::date - u."onboardingCompletedAt"::date) > 0
+        AND (:today::timestamptz::date - u."onboardingCompletedAt"::date) % :intervalDays = 0
         AND u.role IN (:candidateRole, :coachRole)
         AND u."deletedAt" IS NULL
       `,
@@ -1047,8 +1053,8 @@ export class UsersService {
         type: QueryTypes.SELECT,
         raw: true,
         replacements: {
-          startDate,
-          endDate,
+          today,
+          intervalDays,
           onboardingStatus: OnboardingStatus.COMPLETED,
           candidateRole: UserRoles.CANDIDATE,
           coachRole: UserRoles.COACH,

--- a/tests/queues/prepare-recommendation-mails.e2e-spec.ts
+++ b/tests/queues/prepare-recommendation-mails.e2e-spec.ts
@@ -1,0 +1,73 @@
+import { CronTasksProcessor } from 'src/queues/consumers/cron-tasks/cron-tasks.processor';
+
+// CronTasksProcessor only lives in the worker app (ConsumersModule, wired to
+// a real Redis-backed BullMQ queue), which the API test harness
+// (CustomTestingModule) deliberately doesn't boot — see tests/custom-testing.module.ts.
+// This exercises the processor directly with mocked collaborators instead of
+// going through Nest's DI/module system.
+describe('CronTasksProcessor.prepareRecommendationMails', () => {
+  const buildProcessor = (users: { id: string }[]) => {
+    const usersService = {
+      getUsersInactiveForRecommendationMails: jest
+        .fn()
+        .mockResolvedValue(users),
+      findOneWithRelations: jest
+        .fn()
+        .mockImplementation((id: string) => Promise.resolve({ id })),
+      sendRecommendationsMail: jest.fn().mockResolvedValue(undefined),
+    };
+    const userProfilesService = {
+      findOneByUserId: jest
+        .fn()
+        .mockImplementation((id: string) => Promise.resolve({ userId: id })),
+    };
+    const userProfileRecommendationsService = {
+      retrieveOrComputeRecommendationsForUserIdIA: jest
+        .fn()
+        .mockResolvedValue([{}, {}, {}]),
+    };
+    const cronTasksSlackReporterService = {
+      sendCronTaskResultToSlack: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const processor = new CronTasksProcessor(
+      usersService as never,
+      userProfilesService as never,
+      userProfileRecommendationsService as never,
+      {} as never, // usersDeletionService, unused by this method
+      cronTasksSlackReporterService as never,
+      {} as never, // messagingService, unused by this method
+      {} as never, // gamificationService, unused by this method
+      {} as never // recruitementAlertsService, unused by this method
+    );
+
+    return {
+      processor,
+      usersService,
+      userProfileRecommendationsService,
+    };
+  };
+
+  it('fetches eligible users in a single pass, not once per legacy tier', async () => {
+    const { processor, usersService } = buildProcessor([]);
+
+    await processor.prepareRecommendationMails();
+
+    expect(
+      usersService.getUsersInactiveForRecommendationMails
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      usersService.getUsersInactiveForRecommendationMails
+    ).toHaveBeenCalledWith();
+  });
+
+  it('sends a recommendation mail to each user returned by the eligibility query', async () => {
+    const users = [{ id: 'user-1' }, { id: 'user-2' }];
+    const { processor, usersService } = buildProcessor(users);
+
+    const result = await processor.prepareRecommendationMails();
+
+    expect(usersService.sendRecommendationsMail).toHaveBeenCalledTimes(2);
+    expect(result).toContain('2 success');
+  });
+});

--- a/tests/queues/prepare-recommendation-mails.e2e-spec.ts
+++ b/tests/queues/prepare-recommendation-mails.e2e-spec.ts
@@ -8,7 +8,7 @@ import { CronTasksProcessor } from 'src/queues/consumers/cron-tasks/cron-tasks.p
 describe('CronTasksProcessor.prepareRecommendationMails', () => {
   const buildProcessor = (users: { id: string }[]) => {
     const usersService = {
-      getUsersInactiveForRecommendationMails: jest
+      getUsersEligibleForRecommendationMails: jest
         .fn()
         .mockResolvedValue(users),
       findOneWithRelations: jest
@@ -54,10 +54,10 @@ describe('CronTasksProcessor.prepareRecommendationMails', () => {
     await processor.prepareRecommendationMails();
 
     expect(
-      usersService.getUsersInactiveForRecommendationMails
+      usersService.getUsersEligibleForRecommendationMails
     ).toHaveBeenCalledTimes(1);
     expect(
-      usersService.getUsersInactiveForRecommendationMails
+      usersService.getUsersEligibleForRecommendationMails
     ).toHaveBeenCalledWith();
   });
 

--- a/tests/users/recommendation-mails-scheduling.e2e-spec.ts
+++ b/tests/users/recommendation-mails-scheduling.e2e-spec.ts
@@ -15,7 +15,7 @@ import { UserFactory } from 'tests/users/user.factory';
 const onboardingCompletedDaysAgo = (daysAgo: number) =>
   moment().startOf('day').subtract(daysAgo, 'days').toDate();
 
-describe('UsersService.getUsersInactiveForRecommendationMails', () => {
+describe('UsersService.getUsersEligibleForRecommendationMails', () => {
   let app: INestApplication;
   let databaseHelper: DatabaseHelper;
   let userFactory: UserFactory;
@@ -55,7 +55,7 @@ describe('UsersService.getUsersInactiveForRecommendationMails', () => {
       { userProfile: { isAvailable: true, optInRecommendations: true } }
     );
 
-    const result = await usersService.getUsersInactiveForRecommendationMails();
+    const result = await usersService.getUsersEligibleForRecommendationMails();
 
     expect(result.map((u) => u.id)).toContain(user.id);
   });
@@ -66,7 +66,7 @@ describe('UsersService.getUsersInactiveForRecommendationMails', () => {
       { userProfile: { isAvailable: true, optInRecommendations: true } }
     );
 
-    const result = await usersService.getUsersInactiveForRecommendationMails();
+    const result = await usersService.getUsersEligibleForRecommendationMails();
 
     expect(result.map((u) => u.id)).toContain(user.id);
   });
@@ -77,7 +77,7 @@ describe('UsersService.getUsersInactiveForRecommendationMails', () => {
       { userProfile: { isAvailable: true, optInRecommendations: true } }
     );
 
-    const result = await usersService.getUsersInactiveForRecommendationMails();
+    const result = await usersService.getUsersEligibleForRecommendationMails();
 
     expect(result.map((u) => u.id)).not.toContain(user.id);
   });
@@ -88,7 +88,7 @@ describe('UsersService.getUsersInactiveForRecommendationMails', () => {
       { userProfile: { isAvailable: true, optInRecommendations: true } }
     );
 
-    const result = await usersService.getUsersInactiveForRecommendationMails();
+    const result = await usersService.getUsersEligibleForRecommendationMails();
 
     expect(result.map((u) => u.id)).not.toContain(user.id);
   });
@@ -99,7 +99,7 @@ describe('UsersService.getUsersInactiveForRecommendationMails', () => {
       { userProfile: { isAvailable: true, optInRecommendations: false } }
     );
 
-    const result = await usersService.getUsersInactiveForRecommendationMails();
+    const result = await usersService.getUsersEligibleForRecommendationMails();
 
     expect(result.map((u) => u.id)).not.toContain(user.id);
   });
@@ -113,7 +113,7 @@ describe('UsersService.getUsersInactiveForRecommendationMails', () => {
       { userProfile: { isAvailable: true, optInRecommendations: true } }
     );
 
-    const result = await usersService.getUsersInactiveForRecommendationMails();
+    const result = await usersService.getUsersEligibleForRecommendationMails();
 
     expect(result.map((u) => u.id)).not.toContain(user.id);
   });
@@ -124,7 +124,7 @@ describe('UsersService.getUsersInactiveForRecommendationMails', () => {
       { userProfile: { isAvailable: false, optInRecommendations: true } }
     );
 
-    const result = await usersService.getUsersInactiveForRecommendationMails();
+    const result = await usersService.getUsersEligibleForRecommendationMails();
 
     expect(result.map((u) => u.id)).not.toContain(user.id);
   });
@@ -137,17 +137,19 @@ describe('UsersService.getUsersInactiveForRecommendationMails', () => {
     );
 
     const missedDayResult =
-      await usersService.getUsersInactiveForRecommendationMails();
+      await usersService.getUsersEligibleForRecommendationMails();
     expect(missedDayResult.map((u) => u.id)).not.toContain(user.id);
 
-    // ...becomes available again the next day, still off-cycle (11 days).
+    // ...becomes available again, simulated as the next day (11 days into
+    // the cycle, still off-cycle) by shifting onboardingCompletedAt back one
+    // day rather than advancing real time.
     await usersService.update(user.id, {
       onboardingCompletedAt: onboardingCompletedDaysAgo(11),
     });
     await userProfilesService.updateByUserId(user.id, { isAvailable: true });
 
     const offCycleResult =
-      await usersService.getUsersInactiveForRecommendationMails();
+      await usersService.getUsersEligibleForRecommendationMails();
     expect(offCycleResult.map((u) => u.id)).not.toContain(user.id);
   });
 
@@ -160,7 +162,7 @@ describe('UsersService.getUsersInactiveForRecommendationMails', () => {
       { userProfile: { isAvailable: true, optInRecommendations: true } }
     );
 
-    const result = await usersService.getUsersInactiveForRecommendationMails();
+    const result = await usersService.getUsersEligibleForRecommendationMails();
 
     expect(result.map((u) => u.id)).not.toContain(admin.id);
   });

--- a/tests/users/recommendation-mails-scheduling.e2e-spec.ts
+++ b/tests/users/recommendation-mails-scheduling.e2e-spec.ts
@@ -1,0 +1,167 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import moment from 'moment/moment';
+import { QueuesService } from 'src/queues/producers/queues.service';
+import { UserProfilesService } from 'src/user-profiles/user-profiles.service';
+import { UsersService } from 'src/users/users.service';
+import { OnboardingStatus, UserRoles } from 'src/users/users.types';
+import { CustomTestingModule } from 'tests/custom-testing.module';
+import { DatabaseHelper } from 'tests/database.helper';
+import { QueuesServiceMock } from 'tests/queues/queues.service.mock';
+import { UserFactory } from 'tests/users/user.factory';
+
+// Onboarding completed `daysAgo` days ago, truncated to midnight like the
+// production query, so the modulo lands exactly on day boundaries.
+const onboardingCompletedDaysAgo = (daysAgo: number) =>
+  moment().startOf('day').subtract(daysAgo, 'days').toDate();
+
+describe('UsersService.getUsersInactiveForRecommendationMails', () => {
+  let app: INestApplication;
+  let databaseHelper: DatabaseHelper;
+  let userFactory: UserFactory;
+  let usersService: UsersService;
+  let userProfilesService: UserProfilesService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [CustomTestingModule],
+    })
+      .overrideProvider(QueuesService)
+      .useClass(QueuesServiceMock)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    databaseHelper = moduleFixture.get<DatabaseHelper>(DatabaseHelper);
+    userFactory = moduleFixture.get<UserFactory>(UserFactory);
+    usersService = moduleFixture.get<UsersService>(UsersService);
+    userProfilesService =
+      moduleFixture.get<UserProfilesService>(UserProfilesService);
+  });
+
+  afterAll(async () => {
+    await databaseHelper.resetTestDB();
+    await app.close();
+  });
+
+  afterEach(async () => {
+    await databaseHelper.resetTestDB();
+  });
+
+  it('retains an eligible user exactly 10 days after onboarding completion', async () => {
+    const user = await userFactory.create(
+      { onboardingCompletedAt: onboardingCompletedDaysAgo(10) },
+      { userProfile: { isAvailable: true, optInRecommendations: true } }
+    );
+
+    const result = await usersService.getUsersInactiveForRecommendationMails();
+
+    expect(result.map((u) => u.id)).toContain(user.id);
+  });
+
+  it('retains an eligible user exactly 20 days after onboarding completion', async () => {
+    const user = await userFactory.create(
+      { onboardingCompletedAt: onboardingCompletedDaysAgo(20) },
+      { userProfile: { isAvailable: true, optInRecommendations: true } }
+    );
+
+    const result = await usersService.getUsersInactiveForRecommendationMails();
+
+    expect(result.map((u) => u.id)).toContain(user.id);
+  });
+
+  it('excludes a user on the day onboarding was completed (day 0)', async () => {
+    const user = await userFactory.create(
+      { onboardingCompletedAt: onboardingCompletedDaysAgo(0) },
+      { userProfile: { isAvailable: true, optInRecommendations: true } }
+    );
+
+    const result = await usersService.getUsersInactiveForRecommendationMails();
+
+    expect(result.map((u) => u.id)).not.toContain(user.id);
+  });
+
+  it('excludes a user outside the 10-day cycle', async () => {
+    const user = await userFactory.create(
+      { onboardingCompletedAt: onboardingCompletedDaysAgo(7) },
+      { userProfile: { isAvailable: true, optInRecommendations: true } }
+    );
+
+    const result = await usersService.getUsersInactiveForRecommendationMails();
+
+    expect(result.map((u) => u.id)).not.toContain(user.id);
+  });
+
+  it('excludes a user who opted out of recommendation emails', async () => {
+    const user = await userFactory.create(
+      { onboardingCompletedAt: onboardingCompletedDaysAgo(10) },
+      { userProfile: { isAvailable: true, optInRecommendations: false } }
+    );
+
+    const result = await usersService.getUsersInactiveForRecommendationMails();
+
+    expect(result.map((u) => u.id)).not.toContain(user.id);
+  });
+
+  it('excludes a user who has not completed onboarding', async () => {
+    const user = await userFactory.create(
+      {
+        onboardingStatus: OnboardingStatus.IN_PROGRESS,
+        onboardingCompletedAt: null,
+      },
+      { userProfile: { isAvailable: true, optInRecommendations: true } }
+    );
+
+    const result = await usersService.getUsersInactiveForRecommendationMails();
+
+    expect(result.map((u) => u.id)).not.toContain(user.id);
+  });
+
+  it('excludes an unavailable user', async () => {
+    const user = await userFactory.create(
+      { onboardingCompletedAt: onboardingCompletedDaysAgo(10) },
+      { userProfile: { isAvailable: false, optInRecommendations: true } }
+    );
+
+    const result = await usersService.getUsersInactiveForRecommendationMails();
+
+    expect(result.map((u) => u.id)).not.toContain(user.id);
+  });
+
+  it('does not send a catch-up email for a cycle day missed while unavailable', async () => {
+    // Unavailable exactly on their cycle day (10)...
+    const user = await userFactory.create(
+      { onboardingCompletedAt: onboardingCompletedDaysAgo(10) },
+      { userProfile: { isAvailable: false, optInRecommendations: true } }
+    );
+
+    const missedDayResult =
+      await usersService.getUsersInactiveForRecommendationMails();
+    expect(missedDayResult.map((u) => u.id)).not.toContain(user.id);
+
+    // ...becomes available again the next day, still off-cycle (11 days).
+    await usersService.update(user.id, {
+      onboardingCompletedAt: onboardingCompletedDaysAgo(11),
+    });
+    await userProfilesService.updateByUserId(user.id, { isAvailable: true });
+
+    const offCycleResult =
+      await usersService.getUsersInactiveForRecommendationMails();
+    expect(offCycleResult.map((u) => u.id)).not.toContain(user.id);
+  });
+
+  it('respects the roles restricted to candidate and coach', async () => {
+    const admin = await userFactory.create(
+      {
+        role: UserRoles.ADMIN,
+        onboardingCompletedAt: onboardingCompletedDaysAgo(10),
+      },
+      { userProfile: { isAvailable: true, optInRecommendations: true } }
+    );
+
+    const result = await usersService.getUsersInactiveForRecommendationMails();
+
+    expect(result.map((u) => u.id)).not.toContain(admin.id);
+  });
+});


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9348](https://entourage-asso.atlassian.net/browse/EN-9348)
**💬 Commentaire :**

This pull request refactors and improves the logic for sending periodic recommendation emails to users, replacing the previous "inactive for N days" approach with a more predictable, onboarding-based schedule. The eligibility query and scheduling are now based on fixed intervals since onboarding completion, and comprehensive tests have been added to ensure correctness.

**Recommendation email scheduling improvements:**

* Refactored the recommendation email logic to send emails to users every 10 days after onboarding completion, instead of after 10/20/30 days of inactivity. Users are now eligible if their onboarding completion date falls on a 10-day cycle, regardless of connection activity. (`src/users/users.service.ts`, `src/queues/consumers/cron-tasks/cron-tasks.processor.ts`) [[1]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577R1022-R1034) [[2]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L1040-R1057) [[3]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7L501-R516)
* Updated the eligibility SQL query to select users who are available, opted in, completed onboarding, and whose cycle day matches the interval, filtering only candidates and coaches. (`src/users/users.service.ts`)
* Simplified the cron processor to fetch eligible users in a single pass, removing the loop over legacy inactivity tiers and updating log messages and Slack reporting accordingly. (`src/queues/consumers/cron-tasks/cron-tasks.processor.ts`) [[1]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7L501-R516) [[2]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7L584-R581)

**Testing enhancements:**

* Added new E2E tests for the eligibility logic, covering edge cases such as cycle alignment, opt-out, onboarding status, availability, and role restrictions. (`tests/users/recommendation-mails-scheduling.e2e-spec.ts`)
* Added a processor-level test to ensure only one eligibility query is made and that emails are sent to all returned users. (`tests/queues/prepare-recommendation-mails.e2e-spec.ts`)

[EN-9348]: https://entourage-asso.atlassian.net/browse/EN-9348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ