### PR TITLE
Replace isAvailable with unavailableAt in user profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,39 @@ This was added as part of EN-9019. Do not remove the `forwardRef` wrappers.
 
 `user-profiles.controller.ts` reads `@Query('sort')` and branches to `findAllByRelevance` when `sort === 'RELEVANCE'`. The default path is `LAST_CONNECTION` (standard Sequelize query, no embeddings).
 
+## Running e2e tests — never against the dev database
+
+There are two separate Postgres containers: `db` (local dev DB, real/manually-created
+data) and `db-test` (disposable, used only by e2e tests). They are **not** switched by
+`NODE_ENV` alone — `DATABASE_URL`/`DB_HOST` are baked into each container's own env file
+(`.env` for `api`, `.env.test` for `api-test`).
+
+Running `docker exec -e NODE_ENV=dev-test api ...` does **not** redirect the connection:
+the `api` container's `DATABASE_URL` still points at `db`, so any e2e test executed this
+way — including `DatabaseHelper.resetTestDB()` — truncates the **dev database**, not a
+disposable one. This has happened before and wiped real dev data with no backup to
+restore from.
+
+**Always run e2e tests via the `test:e2e:docker` npm script**, which spins up a one-off
+`api-test` container (wired to `db-test`), installs deps, resets/migrates `db-test`, then
+runs the suite — never `docker exec` into the long-running `api` container:
+
+```bash
+pnpm test:e2e:docker -- <path-to-spec>   # e.g. tests/users/foo.e2e-spec.ts
+```
+
+If a previous run left `db-test` with stale open connections (`db:drop`/`db:create`
+failing with "database is being accessed by other users"), clear them first:
+
+```bash
+docker exec db-test psql -U entourage_pro -d postgres -c \
+  "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='entourage_pro_test';"
+```
+
+Before running any command that can mutate or reset a database (test runs, migrations,
+seeders), verify which container/host is actually targeted — don't assume an env var
+override changes the DB connection.
+
 ## Cross-repo workflow
 
 When a change touches an API endpoint, update both repos in the same session:

--- a/src/companies/companies.includes.ts
+++ b/src/companies/companies.includes.ts
@@ -50,7 +50,7 @@ export const companiesWithUsers = ({
     include: [
       {
         model: UserProfile,
-        attributes: ['id', 'hasPicture', 'isAvailable', 'currentJob'],
+        attributes: ['id', 'hasPicture', 'unavailableAt', 'currentJob'],
         include: [...getUserProfileInclude()],
       },
       ...(asCompanyAdmin

--- a/src/cron/cron.service.ts
+++ b/src/cron/cron.service.ts
@@ -389,6 +389,26 @@ export class CronService {
     return { jobId: job.id, status: 'processing' };
   }
 
+  /**
+   * Sends the unavailability notification mail (template 8156335) to the
+   * author of a single, unanswered message when their interlocutor became
+   * unavailable the previous calendar day. Runs daily at 9 AM.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_9AM)
+  async prepareUnavailableSenderNotificationMails() {
+    this.logger.log(
+      'Cron job started: prepareUnavailableSenderNotificationMails'
+    );
+    const job = await this.queuesService.addToCronTasksQueue(
+      Jobs.PREPARE_UNAVAILABLE_SENDER_NOTIFICATION_MAILS,
+      {}
+    );
+    this.logger.log(
+      `Job PREPARE_UNAVAILABLE_SENDER_NOTIFICATION_MAILS created (Job ID: ${job.id})`
+    );
+    return { jobId: job.id, status: 'processing' };
+  }
+
   @Cron(CronExpression.EVERY_DAY_AT_3PM)
   async prepareChurnUsersFeedbackMails() {
     this.logger.log('Cron job started: prepareChurnUsersFeedbackMails');

--- a/src/current-user/dto/current-user-profile.dto.ts
+++ b/src/current-user/dto/current-user-profile.dto.ts
@@ -12,7 +12,7 @@ export type CurrentUserProfileDto = Pick<
   | 'description'
   | 'linkedinUrl'
   | 'department'
-  | 'isAvailable'
+  | 'unavailableAt'
   | 'currentJob'
   | 'optInRecommendations'
   | 'nudges'
@@ -29,7 +29,7 @@ export type CurrentUserProfileCompleteDto = Pick<
   | 'description'
   | 'linkedinUrl'
   | 'department'
-  | 'isAvailable'
+  | 'unavailableAt'
   | 'currentJob'
   | 'optInRecommendations'
   | 'nudges'
@@ -57,7 +57,7 @@ export const generateCurrentUserProfileDto = (
     description: base.description,
     linkedinUrl: base.linkedinUrl,
     department: base.department,
-    isAvailable: base.isAvailable,
+    unavailableAt: base.unavailableAt,
     currentJob: base.currentJob,
     optInRecommendations: base.optInRecommendations,
     nudges: base.nudges,
@@ -79,7 +79,7 @@ export const generateCurrentUserProfileCompleteDto = (
     description: base.description,
     linkedinUrl: base.linkedinUrl,
     department: base.department,
-    isAvailable: base.isAvailable,
+    unavailableAt: base.unavailableAt,
     currentJob: base.currentJob,
     optInRecommendations: base.optInRecommendations,
     nudges: base.nudges,

--- a/src/db/migrations/20260803000000-add-unavailable-at-to-user-profiles.js
+++ b/src/db/migrations/20260803000000-add-unavailable-at-to-user-profiles.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('UserProfiles', 'unavailableAt', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('UserProfiles', 'unavailableAt');
+  },
+};

--- a/src/db/migrations/20260803000001-backfill-unavailable-at-on-user-profiles.js
+++ b/src/db/migrations/20260803000001-backfill-unavailable-at-on-user-profiles.js
@@ -1,0 +1,28 @@
+'use strict';
+
+// Backfill date deliberately far in the past, outside the daily cron's
+// "yesterday" window, so the deploy doesn't trigger a mass send of the
+// new unavailability notification email (see design.md, Risks / Trade-offs).
+const BACKFILL_UNAVAILABLE_AT = '2026-08-01T00:00:00.000Z';
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query(`
+      UPDATE "UserProfiles"
+      SET "unavailableAt" = :backfillDate
+      WHERE "isAvailable" = false
+    `, {
+      replacements: { backfillDate: BACKFILL_UNAVAILABLE_AT },
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query(`
+      UPDATE "UserProfiles"
+      SET "unavailableAt" = NULL
+      WHERE "unavailableAt" = :backfillDate
+    `, {
+      replacements: { backfillDate: BACKFILL_UNAVAILABLE_AT },
+    });
+  },
+};

--- a/src/db/migrations/20260804000000-drop-is-available-from-user-profiles.js
+++ b/src/db/migrations/20260804000000-drop-is-available-from-user-profiles.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.removeColumn('UserProfiles', 'isAvailable');
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('UserProfiles', 'isAvailable', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    });
+  },
+};

--- a/src/external-services/mailjet/mailjet.types.ts
+++ b/src/external-services/mailjet/mailjet.types.ts
@@ -155,6 +155,7 @@ export const MailjetTemplates = {
   MAILER_MESSAGING_FEEDBACK: 6811416,
   MAILER_WARN_ACCOUNT_DELETION: 6611907,
   MAILER_LINKEDIN_SHARE_PROFILE: 8052814,
+  MAILER_UNAVAILABLE_SENDER_NOTIFICATION: 8156335,
 } as const;
 
 export type MailjetTemplateKey = keyof typeof MailjetTemplates;

--- a/src/mails/mails.service.ts
+++ b/src/mails/mails.service.ts
@@ -589,6 +589,41 @@ export class MailsService {
     });
   }
 
+  /**
+   * Mailjet template 8156335 variable naming (fixed external contract, per
+   * the template copy): `sender*` = the actual mail recipient — the author
+   * of the single message that never got a reply, greeted "Bonjour
+   * {{senderFirstName}}" — `addressee*` = the user who became unavailable,
+   * referred to as "vous avez écrit à {{addresseeFirstName}}".
+   */
+  async sendUnavailableSenderNotificationMail(
+    unavailableUser: User,
+    messageAuthor: User
+  ) {
+    this.logger.log(
+      `Sending unavailable sender notification mail to message author with email ${messageAuthor.email}`
+    );
+    await this.queuesService.addToWorkQueue(Jobs.SEND_MAIL, {
+      toEmail: messageAuthor.email,
+      templateId: MailjetTemplates.MAILER_UNAVAILABLE_SENDER_NOTIFICATION,
+      variables: {
+        // Sender (the recipient of this mail — the message author)
+        senderFirstName: messageAuthor.firstName,
+        senderRole: getRoleString(messageAuthor),
+
+        // Addressee (the user who became unavailable)
+        addresseeFirstName: unavailableUser.firstName,
+        addresseeRole: getRoleString(unavailableUser),
+
+        // General
+        zone: messageAuthor.zone,
+        role: messageAuthor.role,
+        staffContact: messageAuthor.staffContact,
+        siteLink: process.env.FRONT_URL,
+      },
+    });
+  }
+
   async sendLinkedInShareProfileMail(coach: User, candidate: User) {
     this.logger.log(
       `Sending LinkedIn share profile mail to coach ${coach.email} for candidate ${candidate.id}`

--- a/src/messaging/messaging.attributes.ts
+++ b/src/messaging/messaging.attributes.ts
@@ -21,5 +21,5 @@ export const conversationParticipantAttributes = [
 ];
 
 export const messageAttributes = ['id', 'content', 'createdAt', 'authorId'];
-export const userProfileAttributes = ['id', 'isAvailable', 'hasPicture'];
+export const userProfileAttributes = ['id', 'unavailableAt', 'hasPicture'];
 export const mediaAttributes = ['id', 'mimeType', 'name', 'size', 's3Key'];

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -1250,7 +1250,7 @@ export class MessagingService {
       FROM "Users" u
       JOIN "UserProfiles" up ON up."userId" = u.id
       WHERE
-        up."isAvailable" IS TRUE
+        up."unavailableAt" IS NULL
         AND u."deletedAt" IS NULL
         AND u.role NOT IN (:adminRole)
         AND u."lastConnection" < NOW() - make_interval(days => :daysWithoutConnection)

--- a/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
+++ b/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
@@ -20,6 +20,8 @@ import { NormalUserRole, UserRoles } from 'src/users/users.types';
 import { UsersDeletionService } from 'src/users-deletion/users-deletion.service';
 import { getZoneNameFromDepartment } from 'src/utils/misc';
 
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
 @Processor(Queues.CRON_TASKS)
 export class CronTasksProcessor extends WorkerHost {
   private readonly logger = new Logger(CronTasksProcessor.name);
@@ -93,6 +95,8 @@ export class CronTasksProcessor extends WorkerHost {
         return this.prepareUnansweredConversationsSms();
       case Jobs.PREPARE_LINKEDIN_SHARE_PROFILE_MAILS:
         return this.prepareLinkedInShareProfileMails();
+      case Jobs.PREPARE_UNAVAILABLE_SENDER_NOTIFICATION_MAILS:
+        return this.prepareUnavailableSenderNotificationMails();
       default:
         this.logger.error(
           `No process method for job ${job.id} with name ${job.name}`
@@ -1309,6 +1313,66 @@ export class CronTasksProcessor extends WorkerHost {
     }
 
     return `Sent ${successIds.length} unavailable user mails`;
+  }
+
+  async prepareUnavailableSenderNotificationMails() {
+    this.logger.log('Preparing unavailable sender notification mails...');
+
+    const yesterdayStart = new Date(
+      new Date().setHours(0, 0, 0, 0) - DAY_IN_MS
+    );
+    const todayStart = new Date(new Date().setHours(0, 0, 0, 0));
+
+    const notifications =
+      await this.usersService.getUnavailableSenderNotifications(
+        yesterdayStart,
+        todayStart
+      );
+
+    this.logger.log(
+      `Found ${notifications.length} unavailable sender notifications to send`
+    );
+
+    const results = await Promise.allSettled(
+      notifications.map(async (dto) => {
+        this.logger.log(
+          `Sending unavailable sender notification mail to ${dto.messageAuthor.email} about ${dto.unavailableUser.id}`
+        );
+        await this.usersService.sendUnavailableSenderNotificationMail(dto);
+      })
+    );
+
+    const { succeeded, successIds, failures } = collectSettledResults(
+      notifications.map((dto, index) => ({
+        id: `${dto.unavailableUser.id}-${dto.messageAuthor.id}-${index}`,
+      })),
+      results,
+      (itemId, reason) => {
+        this.logger.error(
+          `Failed sending unavailable sender notification mail (${itemId})`,
+          reason
+        );
+      }
+    );
+
+    await this.cronTasksSlackReporterService.sendCronTaskResultToSlack(
+      succeeded,
+      '📭 Unavailable sender notifications',
+      {
+        total: notifications.length,
+        success: successIds.length,
+        failure: failures.length,
+      },
+      failures
+    );
+
+    if (!succeeded) {
+      throw new Error(
+        `Failed sending ${failures.length}/${notifications.length} unavailable sender notification mails`
+      );
+    }
+
+    return `Sent ${successIds.length} unavailable sender notification mails`;
   }
 
   async prepareChurnUsersFeedbackMails() {

--- a/src/queues/queues.types.ts
+++ b/src/queues/queues.types.ts
@@ -68,6 +68,8 @@ export const Jobs = {
   PREPARE_WARN_ACCOUNT_DELETION_MAILS: 'prepare_warn_account_deletion_mails',
   PREPARE_UNANSWERED_CONVERSATIONS_SMS: 'prepare_unanswered_conversations_sms',
   PREPARE_LINKEDIN_SHARE_PROFILE_MAILS: 'prepare_linkedin_share_profile_mails',
+  PREPARE_UNAVAILABLE_SENDER_NOTIFICATION_MAILS:
+    'prepare_unavailable_sender_notification_mails',
 
   // Jobs related to embedding queue
   UPDATE_USER_PROFILE_EMBEDDINGS: 'update_user_profile_embeddings',
@@ -119,6 +121,7 @@ type JobsData = {
   [Jobs.PREPARE_WARN_ACCOUNT_DELETION_MAILS]: PrepareWarnAccountDeletionMailsJob;
   [Jobs.PREPARE_UNANSWERED_CONVERSATIONS_SMS]: PrepareUnansweredConversationsSmsJob;
   [Jobs.PREPARE_LINKEDIN_SHARE_PROFILE_MAILS]: PrepareLinkedInShareProfileMailsJob;
+  [Jobs.PREPARE_UNAVAILABLE_SENDER_NOTIFICATION_MAILS]: PrepareUnavailableSenderNotificationMailsJob;
 
   // Embedding queue jobs
   [Jobs.UPDATE_USER_PROFILE_EMBEDDINGS]: UpdateUserProfileEmbeddingsJob;
@@ -257,6 +260,11 @@ export type PrepareWarnAccountDeletionMailsJob = Record<string, never>;
 export type PrepareUnansweredConversationsSmsJob = Record<string, never>;
 
 export type PrepareLinkedInShareProfileMailsJob = Record<string, never>;
+
+export type PrepareUnavailableSenderNotificationMailsJob = Record<
+  string,
+  never
+>;
 
 export interface UpdateUserProfileEmbeddingsJob {
   embeddingTypes: EmbeddingType[];

--- a/src/user-profile-recommendations/user-profile-recommendations-ai.service.ts
+++ b/src/user-profile-recommendations/user-profile-recommendations-ai.service.ts
@@ -213,9 +213,9 @@ export class UserProfileRecommendationsService extends UserProfileRecommendation
     const vec = `'${profileVector}'::vector`;
     const availabilityClause =
       filterByAvailability === true
-        ? `AND up."isAvailable" = true`
+        ? `AND up."unavailableAt" IS NULL`
         : filterByAvailability === false
-          ? `AND up."isAvailable" = false`
+          ? `AND up."unavailableAt" IS NOT NULL`
           : '';
     const elearningClause = isAdminRequester
       ? ''
@@ -261,9 +261,9 @@ export class UserProfileRecommendationsService extends UserProfileRecommendation
     const vec = `'${needsVector}'::vector`;
     const availabilityClause =
       filterByAvailability === true
-        ? `AND up."isAvailable" = true`
+        ? `AND up."unavailableAt" IS NULL`
         : filterByAvailability === false
-          ? `AND up."isAvailable" = false`
+          ? `AND up."unavailableAt" IS NOT NULL`
           : '';
     const elearningClause = isAdminRequester
       ? ''
@@ -586,7 +586,7 @@ ${workloadCases}
     const currentRecos = await this.findRecommendationsByUserId(user.id);
 
     const recIsUnavailable = currentRecos.some(
-      (r) => !r?.recUser?.userProfile?.isAvailable
+      (r) => !!r?.recUser?.userProfile?.unavailableAt
     );
     const recIsLegacy = currentRecos.some(
       (r) => r.finalScore === null || r.rank === null

--- a/src/user-profile-recommendations/user-profile-recommendations-legacy.service.ts
+++ b/src/user-profile-recommendations/user-profile-recommendations-legacy.service.ts
@@ -122,7 +122,7 @@ export class UserProfileRecommendationsLegacyService extends UserProfileRecommen
       ON up.id = upn."userProfileId"
     
     WHERE u."deletedAt" IS NULL
-    AND up."isAvailable" IS TRUE
+    AND up."unavailableAt" IS NULL
     AND up.department IN (${sameRegionDepartmentsOptions.map(
       // remplacer un appostrophe par deux appostrophes
       (department) => `'${department.replace(/'/g, "''")}'`

--- a/src/user-profiles/dto/create-candidate-user-profile.dto.ts
+++ b/src/user-profiles/dto/create-candidate-user-profile.dto.ts
@@ -5,7 +5,7 @@ export class CreateCandidateUserProfileDto extends PickType(UserProfile, [
   'userId',
   'description',
   'department',
-  'isAvailable',
+  'unavailableAt',
   'unavailabilityReason',
   'occupations',
   'linkedinUrl',

--- a/src/user-profiles/dto/create-coach-user-profile.dto.ts
+++ b/src/user-profiles/dto/create-coach-user-profile.dto.ts
@@ -7,7 +7,7 @@ export class CreateCoachUserProfileDto extends PickType(UserProfile, [
   'description',
   'department',
   'currentJob',
-  'isAvailable',
+  'unavailableAt',
   'unavailabilityReason',
   'linkedinUrl',
   'interests',

--- a/src/user-profiles/dto/public-profile.dto.ts
+++ b/src/user-profiles/dto/public-profile.dto.ts
@@ -35,7 +35,6 @@ export type PublicProfileDto = {
   hasPicture: boolean;
   id: string;
   interests: Interest[];
-  isAvailable: boolean;
   lastName: string;
   linkedinUrl?: string;
   nudges: Nudge[];
@@ -44,6 +43,7 @@ export type PublicProfileDto = {
   sectorOccupations: UserProfileSectorOccupation[];
   skills: Skill[];
   totalConversationWithMirrorRoleCount?: number | null;
+  unavailableAt: Date | null;
   userProfileLanguages: UserProfileLanguage[];
   zone: ZoneName;
 };
@@ -67,7 +67,7 @@ export const generatePublicProfileDto = (
     elearningCompletedAt: user.elearningCompletedAt,
     department: userProfile.department,
     currentJob: userProfile.currentJob,
-    isAvailable: userProfile.isAvailable,
+    unavailableAt: userProfile.unavailableAt,
     nudges: userProfile.nudges,
     customNudges: userProfile.customNudges,
     description: userProfile.description,

--- a/src/user-profiles/dto/user-profile.dto.ts
+++ b/src/user-profiles/dto/user-profile.dto.ts
@@ -11,7 +11,7 @@ export const generateUserProfileDto = (
   }
   const dto = {
     id: userProfile.id,
-    isAvailable: userProfile.isAvailable,
+    unavailableAt: userProfile.unavailableAt,
     department: userProfile.department,
     currentJob: userProfile.currentJob,
     nudges: userProfile.nudges,

--- a/src/user-profiles/models/user-profile.attributes.ts
+++ b/src/user-profiles/models/user-profile.attributes.ts
@@ -5,7 +5,7 @@ export const UserProfilesAttributes = [
   'currentJob',
   'department',
   'description',
-  'isAvailable',
+  'unavailableAt',
   'linkedinUrl',
   'optInNewsletter',
   'optInRecommendations',

--- a/src/user-profiles/models/user-profile.model.ts
+++ b/src/user-profiles/models/user-profile.model.ts
@@ -82,6 +82,7 @@ export class UserProfile extends Model {
   description: string;
 
   @ApiProperty()
+  @IsDate()
   @AllowNull(true)
   @Column
   unavailableAt: Date;

--- a/src/user-profiles/models/user-profile.model.ts
+++ b/src/user-profiles/models/user-profile.model.ts
@@ -82,11 +82,9 @@ export class UserProfile extends Model {
   description: string;
 
   @ApiProperty()
-  @IsBoolean()
-  @AllowNull(false)
-  @Default(true)
+  @AllowNull(true)
   @Column
-  isAvailable: boolean;
+  unavailableAt: Date;
 
   @ApiProperty({ enum: UnavailabilityReason })
   @IsEnum(UnavailabilityReason)

--- a/src/user-profiles/models/user-profile.model.ts
+++ b/src/user-profiles/models/user-profile.model.ts
@@ -82,7 +82,6 @@ export class UserProfile extends Model {
   description: string;
 
   @ApiProperty()
-  @IsDate()
   @AllowNull(true)
   @Column
   unavailableAt: Date;

--- a/src/user-profiles/user-profiles.service.ts
+++ b/src/user-profiles/user-profiles.service.ts
@@ -63,6 +63,7 @@ import {
 } from './models/user-profile.include';
 import { ContactTypeEnum } from './user-profiles.types';
 import {
+  availabilityWhere,
   profileVisibilityEligibilityWhere,
   userProfileSearchQuery,
 } from './user-profiles.utils';
@@ -300,7 +301,7 @@ export class UserProfilesService {
         ...searchOptions,
         ...(contactTypesWhereClause ?? {}),
         ...(departmentsOptions ?? {}),
-        ...(isAvailable !== undefined ? { isAvailable } : {}),
+        ...availabilityWhere(isAvailable),
       },
       group: ['UserProfile.id', 'user.id', 'user.lastConnection'],
     });
@@ -484,7 +485,7 @@ export class UserProfilesService {
         ...searchOptions,
         ...(contactTypesWhereClause ?? {}),
         ...(departmentsOptions ?? {}),
-        ...(isAvailable !== undefined ? { isAvailable } : {}),
+        ...availabilityWhere(isAvailable),
       },
       group: ['UserProfile.id', 'user.id'],
     });
@@ -562,7 +563,7 @@ export class UserProfilesService {
     const targetRole =
       role === UserRoles.CANDIDATE ? UserRoles.COACH : UserRoles.CANDIDATE;
 
-    const baseWhere = { isAvailable: true };
+    const baseWhere: WhereOptions<UserProfile> = { unavailableAt: null };
     const userInclude = {
       model: User,
       as: 'user',
@@ -1114,7 +1115,7 @@ export class UserProfilesService {
   async setUserAsUnavailableDueToInactivity(user: User): Promise<void> {
     await this.mailsService.sendAutoSetUnavailableMail(user);
     await this.updateByUserId(user.id, {
-      isAvailable: false,
+      unavailableAt: new Date(),
       unavailabilityReason: UnavailabilityReason.INACTIVITY,
     });
   }

--- a/src/user-profiles/user-profiles.utils.ts
+++ b/src/user-profiles/user-profiles.utils.ts
@@ -2,6 +2,7 @@ import { Op, WhereOptions } from 'sequelize';
 import { User } from 'src/users/models';
 import { OnboardingStatus } from 'src/users/users.types';
 import { searchInColumnWhereOption } from 'src/utils/misc';
+import { UserProfile } from './models';
 
 export function userProfileSearchQuery(query = '') {
   return [
@@ -42,4 +43,18 @@ export function isProfileVisibilityEligible(
     user.onboardingStatus === OnboardingStatus.COMPLETED &&
     user.elearningCompletedAt != null
   );
+}
+
+/**
+ * Translates the public "isAvailable" filter (still expressed as a boolean at
+ * the API boundary) into a `WhereOptions` targeting `unavailableAt`, the
+ * actual source of truth: `NULL` = available, a date = unavailable since then.
+ */
+export function availabilityWhere(
+  isAvailable: boolean | undefined
+): WhereOptions<UserProfile> {
+  if (isAvailable === undefined) return {};
+  return isAvailable
+    ? { unavailableAt: null }
+    : { unavailableAt: { [Op.ne]: null } };
 }

--- a/src/users-creation/users-creation.controller.ts
+++ b/src/users-creation/users-creation.controller.ts
@@ -237,7 +237,7 @@ export class UsersCreationController {
           await this.usersCreationService.updateUserProfileByUserId(
             createdUserId,
             {
-              isAvailable: false,
+              unavailableAt: new Date(),
             }
           );
         }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -65,6 +65,14 @@ export type NoResponseToFirstMessageResultDto = {
   user: User;
 };
 
+export type UnavailableSenderNotificationResultDto = {
+  // The author of the single, unanswered message — the actual recipient of
+  // this notification mail (reassured that they won't get a reply because
+  // the other person became unavailable).
+  messageAuthor: User;
+  unavailableUser: User;
+};
+
 @Injectable()
 export class UsersService {
   constructor(
@@ -977,6 +985,84 @@ export class UsersService {
     );
   }
 
+  /**
+   * For each UserProfile that became unavailable within [startDate, endDate),
+   * finds every single-message conversation where that user is the recipient
+   * of the sole message — the message author is the one to notify (they sent
+   * a message and will never get a reply).
+   * Reuses the `GROUP BY conversationId HAVING COUNT(*) = 1` pattern from
+   * `getUsersWithNoResponseToFirstMessage`.
+   */
+  async getUnavailableSenderNotifications(
+    startDate: Date,
+    endDate: Date
+  ): Promise<UnavailableSenderNotificationResultDto[]> {
+    const rows: { authorId: string; unavailableUserId: string }[] =
+      await this.userModel.sequelize.query(
+        `
+      SELECT
+        m."authorId" as "authorId",
+        up."userId" as "unavailableUserId"
+      FROM "Messages" m
+      INNER JOIN (
+        SELECT "conversationId"
+        FROM "Messages"
+        GROUP BY "conversationId"
+        HAVING COUNT(*) = 1
+      ) AS single_message_conversations
+        ON single_message_conversations."conversationId" = m."conversationId"
+      INNER JOIN "ConversationParticipants" cp
+        ON cp."conversationId" = m."conversationId"
+        AND cp."userId" != m."authorId"
+      INNER JOIN "Users" u ON u.id = cp."userId"
+      INNER JOIN "UserProfiles" up ON up."userId" = u.id
+      INNER JOIN "Users" author ON author.id = m."authorId"
+      WHERE up."unavailableAt" >= :startDate
+        AND up."unavailableAt" < :endDate
+        AND u."deletedAt" IS NULL
+        AND author."deletedAt" IS NULL
+      `,
+        {
+          type: QueryTypes.SELECT,
+          raw: true,
+          replacements: { startDate, endDate },
+        }
+      );
+
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const uniqueUserIds = Array.from(
+      new Set(rows.flatMap((row) => [row.authorId, row.unavailableUserId]))
+    );
+    const users = await this.findByIdsWithRelations(uniqueUserIds);
+    const userById = new Map(users.map((user) => [user.id, user]));
+
+    return rows
+      .map((row) => {
+        const messageAuthor = userById.get(row.authorId);
+        const unavailableUser = userById.get(row.unavailableUserId);
+        if (!messageAuthor || !unavailableUser) {
+          return null;
+        }
+        return { messageAuthor, unavailableUser };
+      })
+      .filter(
+        (result): result is UnavailableSenderNotificationResultDto =>
+          result !== null
+      );
+  }
+
+  async sendUnavailableSenderNotificationMail(
+    dto: UnavailableSenderNotificationResultDto
+  ) {
+    return this.mailsService.sendUnavailableSenderNotificationMail(
+      dto.unavailableUser,
+      dto.messageAuthor
+    );
+  }
+
   async sendReminderToCompleteProfile(user: User) {
     return this.mailsService.sendReminderToCompleteProfile(user);
   }
@@ -1036,7 +1122,7 @@ export class UsersService {
       FROM "Users" u
       JOIN "UserProfiles" up ON u.id = up."userId"
       WHERE
-        up."isAvailable" IS TRUE
+        up."unavailableAt" IS NULL
         AND u."lastConnection" >= :startDate
         AND u."lastConnection" < :endDate
         AND u."onboardingStatus" = :onboardingStatus
@@ -1186,7 +1272,7 @@ export class UsersService {
       LEFT JOIN "Users" r ON r."refererId" = u.id
       LEFT JOIN "UserProfiles" up ON u."id" = up."userId"
       WHERE u.role = 'Prescripteur'
-        AND up."isAvailable" = TRUE
+        AND up."unavailableAt" IS NULL
         AND u."createdAt" >= :startDate
         AND u."createdAt" < :endDate
         AND u."deletedAt" IS NULL
@@ -1429,7 +1515,7 @@ export class UsersService {
         GROUP BY "conversationId"
       ) lm ON lm."conversationId" = c.id
       WHERE (cp."seenAt" IS NULL OR lm."lastMessageTime" >= cp."seenAt")
-        AND up."isAvailable" IS TRUE
+        AND up."unavailableAt" IS NULL
         AND lm."lastMessageTime" >= CURRENT_TIMESTAMP - INTERVAL '${
           daysSinceLastConversation + 1
         } days'

--- a/tests/current-user/current-user.e2e-spec.ts
+++ b/tests/current-user/current-user.e2e-spec.ts
@@ -113,7 +113,7 @@ describe('CurrentUser', () => {
         id: expect.any(String),
         hasPicture: expect.any(Boolean),
         hasExternalCv: expect.any(Boolean),
-        isAvailable: expect.any(Boolean),
+        unavailableAt: null,
       });
       expect(response.body).not.toHaveProperty('experiences');
       expect(response.body).not.toHaveProperty('formations');

--- a/tests/public-cvs/public-cvs.e2e-spec.ts
+++ b/tests/public-cvs/public-cvs.e2e-spec.ts
@@ -121,7 +121,7 @@ describe('PublicCVs', () => {
       {
         userProfile: {
           department: 'Nord (59)',
-          isAvailable: true,
+          unavailableAt: null,
           hasPicture: true,
           description: 'Description détaillée de mon parcours professionnel',
           currentJob: 'Développeur Web',
@@ -190,7 +190,7 @@ describe('PublicCVs', () => {
       {
         userProfile: {
           department: 'Nord (59)',
-          isAvailable: true,
+          unavailableAt: null,
           hasPicture: false, // Pas de photo
           description: 'Description de mon parcours',
           sectorOccupations: [
@@ -216,7 +216,7 @@ describe('PublicCVs', () => {
       {
         userProfile: {
           department: 'Nord (59)',
-          isAvailable: true,
+          unavailableAt: null,
           hasPicture: true, // A une photo
           // Peu de champs remplis, ce qui donnera un taux de complétion < 70%
           sectorOccupations: [
@@ -245,7 +245,7 @@ describe('PublicCVs', () => {
       {
         userProfile: {
           department: 'Paris (75)',
-          isAvailable: true,
+          unavailableAt: null,
           hasPicture: true,
           currentJob: 'Développeur',
           sectorOccupations: [

--- a/tests/user-creation/pre-registration-compatible-profiles.e2e-spec.ts
+++ b/tests/user-creation/pre-registration-compatible-profiles.e2e-spec.ts
@@ -153,19 +153,19 @@ describe('UsersCreation - GET /user/registration/compatible-profiles', () => {
         userFactory,
         3,
         { role: UserRoles.COACH },
-        { userProfile: { isAvailable: true } }
+        { userProfile: { unavailableAt: null } }
       );
       await databaseHelper.createEntities(
         userFactory,
         1,
         { role: UserRoles.COACH },
-        { userProfile: { isAvailable: false } }
+        { userProfile: { unavailableAt: new Date() } }
       );
       await databaseHelper.createEntities(
         userFactory,
         2,
         { role: UserRoles.CANDIDATE },
-        { userProfile: { isAvailable: true } }
+        { userProfile: { unavailableAt: null } }
       );
 
       const response = await getCompatibleProfiles(
@@ -188,13 +188,13 @@ describe('UsersCreation - GET /user/registration/compatible-profiles', () => {
         userFactory,
         2,
         { role: UserRoles.CANDIDATE },
-        { userProfile: { isAvailable: true } }
+        { userProfile: { unavailableAt: null } }
       );
       await databaseHelper.createEntities(
         userFactory,
         2,
         { role: UserRoles.COACH },
-        { userProfile: { isAvailable: true } }
+        { userProfile: { unavailableAt: null } }
       );
 
       const response = await getCompatibleProfiles(`role=${UserRoles.COACH}`);
@@ -213,7 +213,7 @@ describe('UsersCreation - GET /user/registration/compatible-profiles', () => {
         userFactory,
         8,
         { role: UserRoles.COACH },
-        { userProfile: { isAvailable: true } }
+        { userProfile: { unavailableAt: null } }
       );
 
       const response = await getCompatibleProfiles(
@@ -230,7 +230,7 @@ describe('UsersCreation - GET /user/registration/compatible-profiles', () => {
         userFactory,
         2,
         { role: UserRoles.COACH },
-        { userProfile: { isAvailable: false } }
+        { userProfile: { unavailableAt: new Date() } }
       );
 
       const response = await getCompatibleProfiles(
@@ -250,7 +250,7 @@ describe('UsersCreation - GET /user/registration/compatible-profiles', () => {
         userFactory,
         1,
         { role: UserRoles.COACH },
-        { userProfile: { isAvailable: true } }
+        { userProfile: { unavailableAt: null } }
       );
 
       const response = await getCompatibleProfiles(

--- a/tests/user-profiles/user-profiles.e2e-spec.ts
+++ b/tests/user-profiles/user-profiles.e2e-spec.ts
@@ -1540,13 +1540,13 @@ describe('UserProfiles', () => {
               userFactory,
               2,
               { role: UserRoles.CANDIDATE },
-              { userProfile: { isAvailable: true } }
+              { userProfile: { unavailableAt: null } }
             );
             await databaseHelper.createEntities(
               userFactory,
               2,
               { role: UserRoles.CANDIDATE },
-              { userProfile: { isAvailable: false } }
+              { userProfile: { unavailableAt: new Date() } }
             );
 
             const expectedIds = availableCandidates.map(({ id }) => id);
@@ -1570,13 +1570,13 @@ describe('UserProfiles', () => {
               userFactory,
               2,
               { role: UserRoles.CANDIDATE },
-              { userProfile: { isAvailable: true } }
+              { userProfile: { unavailableAt: null } }
             );
             const unavailableCandidates = await databaseHelper.createEntities(
               userFactory,
               2,
               { role: UserRoles.CANDIDATE },
-              { userProfile: { isAvailable: false } }
+              { userProfile: { unavailableAt: new Date() } }
             );
 
             const expectedIds = unavailableCandidates.map(({ id }) => id);
@@ -1600,13 +1600,13 @@ describe('UserProfiles', () => {
               userFactory,
               2,
               { role: UserRoles.CANDIDATE },
-              { userProfile: { isAvailable: true } }
+              { userProfile: { unavailableAt: null } }
             );
             await databaseHelper.createEntities(
               userFactory,
               2,
               { role: UserRoles.CANDIDATE },
-              { userProfile: { isAvailable: false } }
+              { userProfile: { unavailableAt: new Date() } }
             );
 
             const response: APIResponse<UserProfilesController['findAll']> =
@@ -1796,7 +1796,7 @@ describe('UserProfiles', () => {
             {
               userProfile: {
                 department: 'Rhône (69)',
-                isAvailable: true,
+                unavailableAt: null,
                 sectorOccupations: [
                   {
                     businessSectorId: businessSector1.id,
@@ -1816,7 +1816,7 @@ describe('UserProfiles', () => {
               userProfile: {
                 department: 'Rhône (69)',
                 currentJob: 'peintre',
-                isAvailable: true,
+                unavailableAt: null,
                 nudges: [{ id: nudgeInterview.id }],
                 sectorOccupations: [
                   {
@@ -1850,7 +1850,7 @@ describe('UserProfiles', () => {
             .set('authorization', `Bearer ${loggedInAdmin.token}`)
             .send({
               description: 'hello',
-              isAvailable: false,
+              unavailableAt: new Date(),
               department: 'Paris (75)',
             });
           expect(response.status).toBe(403);
@@ -1863,7 +1863,7 @@ describe('UserProfiles', () => {
             .set('authorization', `Bearer ${loggedInReferer.token}`)
             .send({
               description: 'hello',
-              isAvailable: false,
+              unavailableAt: new Date(),
               department: 'Paris (75)',
             });
           expect(response.status).toBe(403);
@@ -1876,7 +1876,7 @@ describe('UserProfiles', () => {
             .set('authorization', `Bearer ${loggedInCoach.token}`)
             .send({
               description: 'hello',
-              isAvailable: false,
+              unavailableAt: new Date(),
               department: 'Paris (75)',
             });
           expect(response.status).toBe(403);
@@ -1889,7 +1889,7 @@ describe('UserProfiles', () => {
             .set('authorization', `Bearer ${loggedInCandidate.token}`)
             .send({
               description: 'hello',
-              isAvailable: false,
+              unavailableAt: new Date(),
               department: 'Paris (75)',
             });
           expect(response.status).toBe(403);
@@ -1901,7 +1901,7 @@ describe('UserProfiles', () => {
           const updatedProfile = {
             description: 'hello',
             department: 'Paris (75)',
-            isAvailable: false,
+            unavailableAt: new Date(),
             sectorOccupations: [
               {
                 businessSectorId: businessSector.id,
@@ -1950,7 +1950,7 @@ describe('UserProfiles', () => {
           const updatedProfile: UserProfileWithPartialAssociations = {
             description: 'hello',
             department: 'Paris (75)',
-            isAvailable: false,
+            unavailableAt: new Date(),
             sectorOccupations: [
               {
                 businessSectorId: businessSector1.id,
@@ -1974,7 +1974,7 @@ describe('UserProfiles', () => {
             description: 'hello',
             currentJob: 'mécanicien',
             department: 'Paris (75)',
-            isAvailable: false,
+            unavailableAt: new Date(),
             businessSectors: [{ name: 'id' }] as BusinessSector[],
             // helpOffers: [{ name: 'network' }] as HelpOffer[],
           };
@@ -1994,7 +1994,7 @@ describe('UserProfiles', () => {
             description: 'hello',
             currentJob: 'mécanicien',
             department: 'Paris (75)',
-            isAvailable: false,
+            unavailableAt: new Date(),
             sectorOccupations: [
               {
                 businessSectorId: businessSector.id,
@@ -2016,6 +2016,7 @@ describe('UserProfiles', () => {
           expect(response.body).toEqual(
             expect.objectContaining({
               ...updatedProfile,
+              unavailableAt: updatedProfile.unavailableAt.toISOString(),
               sectorOccupations: [
                 expect.objectContaining({
                   businessSector: expect.objectContaining({ name: 'Sector 1' }),

--- a/tests/user-profiles/user-profiles.helper.ts
+++ b/tests/user-profiles/user-profiles.helper.ts
@@ -42,7 +42,7 @@ export class UserProfilesHelper {
       description: userProfileData.description,
       currentJob: userProfileData.currentJob,
       department: userProfileData.department,
-      unavailableAt: userProfileData.unavailableAt,
+      unavailableAt: userProfileData.unavailableAt?.toISOString() ?? null,
       sectorOccupations: expect.arrayContaining(
         userProfileData.sectorOccupations.map((sectorOccupation) => ({
           id: sectorOccupation.id,
@@ -58,7 +58,7 @@ export class UserProfilesHelper {
         }))
       ),
       nudges: userProfileData.nudges,
-    } as Partial<UserProfile & User>;
+    } as unknown as Partial<UserProfile & User>;
     if (completeExpected) {
       config.experiences = expect.arrayContaining(
         userProfileData.experiences.map((experience) => ({

--- a/tests/user-profiles/user-profiles.helper.ts
+++ b/tests/user-profiles/user-profiles.helper.ts
@@ -42,7 +42,7 @@ export class UserProfilesHelper {
       description: userProfileData.description,
       currentJob: userProfileData.currentJob,
       department: userProfileData.department,
-      isAvailable: userProfileData.isAvailable,
+      unavailableAt: userProfileData.unavailableAt,
       sectorOccupations: expect.arrayContaining(
         userProfileData.sectorOccupations.map((sectorOccupation) => ({
           id: sectorOccupation.id,

--- a/tests/users/recommendation-mails-scheduling.e2e-spec.ts
+++ b/tests/users/recommendation-mails-scheduling.e2e-spec.ts
@@ -52,7 +52,7 @@ describe('UsersService.getUsersEligibleForRecommendationMails', () => {
   it('retains an eligible user exactly 10 days after onboarding completion', async () => {
     const user = await userFactory.create(
       { onboardingCompletedAt: onboardingCompletedDaysAgo(10) },
-      { userProfile: { isAvailable: true, optInRecommendations: true } }
+      { userProfile: { unavailableAt: null, optInRecommendations: true } }
     );
 
     const result = await usersService.getUsersEligibleForRecommendationMails();
@@ -63,7 +63,7 @@ describe('UsersService.getUsersEligibleForRecommendationMails', () => {
   it('retains an eligible user exactly 20 days after onboarding completion', async () => {
     const user = await userFactory.create(
       { onboardingCompletedAt: onboardingCompletedDaysAgo(20) },
-      { userProfile: { isAvailable: true, optInRecommendations: true } }
+      { userProfile: { unavailableAt: null, optInRecommendations: true } }
     );
 
     const result = await usersService.getUsersEligibleForRecommendationMails();
@@ -74,7 +74,7 @@ describe('UsersService.getUsersEligibleForRecommendationMails', () => {
   it('excludes a user on the day onboarding was completed (day 0)', async () => {
     const user = await userFactory.create(
       { onboardingCompletedAt: onboardingCompletedDaysAgo(0) },
-      { userProfile: { isAvailable: true, optInRecommendations: true } }
+      { userProfile: { unavailableAt: null, optInRecommendations: true } }
     );
 
     const result = await usersService.getUsersEligibleForRecommendationMails();
@@ -85,7 +85,7 @@ describe('UsersService.getUsersEligibleForRecommendationMails', () => {
   it('excludes a user outside the 10-day cycle', async () => {
     const user = await userFactory.create(
       { onboardingCompletedAt: onboardingCompletedDaysAgo(7) },
-      { userProfile: { isAvailable: true, optInRecommendations: true } }
+      { userProfile: { unavailableAt: null, optInRecommendations: true } }
     );
 
     const result = await usersService.getUsersEligibleForRecommendationMails();
@@ -96,7 +96,7 @@ describe('UsersService.getUsersEligibleForRecommendationMails', () => {
   it('excludes a user who opted out of recommendation emails', async () => {
     const user = await userFactory.create(
       { onboardingCompletedAt: onboardingCompletedDaysAgo(10) },
-      { userProfile: { isAvailable: true, optInRecommendations: false } }
+      { userProfile: { unavailableAt: null, optInRecommendations: false } }
     );
 
     const result = await usersService.getUsersEligibleForRecommendationMails();
@@ -110,7 +110,7 @@ describe('UsersService.getUsersEligibleForRecommendationMails', () => {
         onboardingStatus: OnboardingStatus.IN_PROGRESS,
         onboardingCompletedAt: null,
       },
-      { userProfile: { isAvailable: true, optInRecommendations: true } }
+      { userProfile: { unavailableAt: null, optInRecommendations: true } }
     );
 
     const result = await usersService.getUsersEligibleForRecommendationMails();
@@ -121,7 +121,7 @@ describe('UsersService.getUsersEligibleForRecommendationMails', () => {
   it('excludes an unavailable user', async () => {
     const user = await userFactory.create(
       { onboardingCompletedAt: onboardingCompletedDaysAgo(10) },
-      { userProfile: { isAvailable: false, optInRecommendations: true } }
+      { userProfile: { unavailableAt: new Date(), optInRecommendations: true } }
     );
 
     const result = await usersService.getUsersEligibleForRecommendationMails();
@@ -133,7 +133,7 @@ describe('UsersService.getUsersEligibleForRecommendationMails', () => {
     // Unavailable exactly on their cycle day (10)...
     const user = await userFactory.create(
       { onboardingCompletedAt: onboardingCompletedDaysAgo(10) },
-      { userProfile: { isAvailable: false, optInRecommendations: true } }
+      { userProfile: { unavailableAt: new Date(), optInRecommendations: true } }
     );
 
     const missedDayResult =
@@ -146,7 +146,7 @@ describe('UsersService.getUsersEligibleForRecommendationMails', () => {
     await usersService.update(user.id, {
       onboardingCompletedAt: onboardingCompletedDaysAgo(11),
     });
-    await userProfilesService.updateByUserId(user.id, { isAvailable: true });
+    await userProfilesService.updateByUserId(user.id, { unavailableAt: null });
 
     const offCycleResult =
       await usersService.getUsersEligibleForRecommendationMails();
@@ -159,7 +159,7 @@ describe('UsersService.getUsersEligibleForRecommendationMails', () => {
         role: UserRoles.ADMIN,
         onboardingCompletedAt: onboardingCompletedDaysAgo(10),
       },
-      { userProfile: { isAvailable: true, optInRecommendations: true } }
+      { userProfile: { unavailableAt: null, optInRecommendations: true } }
     );
 
     const result = await usersService.getUsersEligibleForRecommendationMails();

--- a/tests/users/unavailable-sender-notification.e2e-spec.ts
+++ b/tests/users/unavailable-sender-notification.e2e-spec.ts
@@ -1,0 +1,206 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MailjetTemplates } from 'src/external-services/mailjet/mailjet.types';
+import { QueuesService } from 'src/queues/producers/queues.service';
+import { Jobs } from 'src/queues/queues.types';
+import { UsersService } from 'src/users/users.service';
+import { UserRoles } from 'src/users/users.types';
+import { CustomTestingModule } from 'tests/custom-testing.module';
+import { DatabaseHelper } from 'tests/database.helper';
+import { ConversationFactory } from 'tests/messaging/conversation.factory';
+import { MessagingHelper } from 'tests/messaging/messaging.helper';
+import { QueuesServiceMock } from 'tests/queues/queues.service.mock';
+import { LoggedInUser, UsersHelper } from 'tests/users/users.helper';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+describe('UNAVAILABLE SENDER NOTIFICATION', () => {
+  let app: INestApplication;
+
+  let addToWorkQueueSpy: jest.SpyInstance;
+
+  let databaseHelper: DatabaseHelper;
+  let usersHelper: UsersHelper;
+  let usersService: UsersService;
+  let conversationFactory: ConversationFactory;
+  let messagingHelper: MessagingHelper;
+
+  // The daily cron targets profiles whose `unavailableAt` falls within
+  // yesterday's calendar day: [yesterday 00:00, today 00:00[.
+  const yesterdayStart = new Date(new Date().setHours(0, 0, 0, 0) - DAY_IN_MS);
+  const todayStart = new Date(new Date().setHours(0, 0, 0, 0));
+  const yesterdayNoon = new Date(
+    yesterdayStart.getTime() + 12 * 60 * 60 * 1000
+  );
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [CustomTestingModule],
+    })
+      .overrideProvider(QueuesService)
+      .useClass(QueuesServiceMock)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    databaseHelper = moduleFixture.get<DatabaseHelper>(DatabaseHelper);
+    usersHelper = moduleFixture.get<UsersHelper>(UsersHelper);
+    usersService = moduleFixture.get<UsersService>(UsersService);
+    conversationFactory =
+      moduleFixture.get<ConversationFactory>(ConversationFactory);
+    messagingHelper = moduleFixture.get<MessagingHelper>(MessagingHelper);
+
+    addToWorkQueueSpy = jest.spyOn(
+      QueuesServiceMock.prototype,
+      'addToWorkQueue'
+    );
+
+    await databaseHelper.resetTestDB();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(async () => {
+    await databaseHelper.resetTestDB();
+    addToWorkQueueSpy?.mockClear();
+  });
+
+  // `messageAuthor` sends the single message; `unavailableUser` is the
+  // other participant, the one whose `unavailableAt` the cron checks.
+  const createUnansweredConversation = async (
+    unavailableUser: LoggedInUser,
+    messageAuthor: LoggedInUser
+  ) => {
+    const conversation = await conversationFactory.create();
+    await messagingHelper.associationParticipantsToConversation(
+      conversation.id,
+      [unavailableUser.user.id, messageAuthor.user.id]
+    );
+    await messagingHelper.createMessage(conversation.id, messageAuthor.user.id);
+    return conversation;
+  };
+
+  it('notifies the message author when the other participant became unavailable yesterday and never replied', async () => {
+    const unavailableUser = await usersHelper.createLoggedInUser(
+      { role: UserRoles.COACH },
+      { userProfile: { unavailableAt: yesterdayNoon } }
+    );
+    const messageAuthor = await usersHelper.createLoggedInUser({
+      role: UserRoles.CANDIDATE,
+    });
+
+    await createUnansweredConversation(unavailableUser, messageAuthor);
+
+    const notifications = await usersService.getUnavailableSenderNotifications(
+      yesterdayStart,
+      todayStart
+    );
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].unavailableUser.id).toBe(unavailableUser.user.id);
+    expect(notifications[0].messageAuthor.id).toBe(messageAuthor.user.id);
+
+    await usersService.sendUnavailableSenderNotificationMail(notifications[0]);
+
+    // The message author — not the now-unavailable user — is the actual
+    // mail recipient, reassured that they won't get a reply. Per the
+    // template copy ("Bonjour {{senderFirstName}} ... vous avez écrit à
+    // {{addresseeFirstName}}"), `sender*` names the recipient and
+    // `addressee*` names the user who became unavailable.
+    expect(addToWorkQueueSpy).toHaveBeenCalledWith(
+      Jobs.SEND_MAIL,
+      expect.objectContaining({
+        toEmail: messageAuthor.user.email,
+        templateId: MailjetTemplates.MAILER_UNAVAILABLE_SENDER_NOTIFICATION,
+        variables: expect.objectContaining({
+          senderFirstName: messageAuthor.user.firstName,
+          addresseeFirstName: unavailableUser.user.firstName,
+        }),
+      })
+    );
+  });
+
+  it('does not return the conversation when the unavailable user has replied', async () => {
+    const unavailableUser = await usersHelper.createLoggedInUser(
+      { role: UserRoles.COACH },
+      { userProfile: { unavailableAt: yesterdayNoon } }
+    );
+    const messageAuthor = await usersHelper.createLoggedInUser({
+      role: UserRoles.CANDIDATE,
+    });
+
+    const conversation = await createUnansweredConversation(
+      unavailableUser,
+      messageAuthor
+    );
+    await messagingHelper.createMessage(
+      conversation.id,
+      unavailableUser.user.id
+    );
+
+    const notifications = await usersService.getUnavailableSenderNotifications(
+      yesterdayStart,
+      todayStart
+    );
+
+    expect(notifications).toHaveLength(0);
+  });
+
+  it('returns one notification per qualifying conversation for the same unavailable user', async () => {
+    const unavailableUser = await usersHelper.createLoggedInUser(
+      { role: UserRoles.COACH },
+      { userProfile: { unavailableAt: yesterdayNoon } }
+    );
+    const firstMessageAuthor = await usersHelper.createLoggedInUser({
+      role: UserRoles.CANDIDATE,
+    });
+    const secondMessageAuthor = await usersHelper.createLoggedInUser({
+      role: UserRoles.CANDIDATE,
+    });
+
+    await createUnansweredConversation(unavailableUser, firstMessageAuthor);
+    await createUnansweredConversation(unavailableUser, secondMessageAuthor);
+
+    const notifications = await usersService.getUnavailableSenderNotifications(
+      yesterdayStart,
+      todayStart
+    );
+
+    expect(notifications).toHaveLength(2);
+    expect(notifications.map((n) => n.messageAuthor.id).sort()).toEqual(
+      [firstMessageAuthor.user.id, secondMessageAuthor.user.id].sort()
+    );
+  });
+
+  it('sends a new notification on every unavailability pass, without deduplication', async () => {
+    const unavailableUser = await usersHelper.createLoggedInUser(
+      { role: UserRoles.COACH },
+      { userProfile: { unavailableAt: yesterdayNoon } }
+    );
+    const messageAuthor = await usersHelper.createLoggedInUser({
+      role: UserRoles.CANDIDATE,
+    });
+
+    await createUnansweredConversation(unavailableUser, messageAuthor);
+
+    const firstPassNotifications =
+      await usersService.getUnavailableSenderNotifications(
+        yesterdayStart,
+        todayStart
+      );
+    const secondPassNotifications =
+      await usersService.getUnavailableSenderNotifications(
+        yesterdayStart,
+        todayStart
+      );
+
+    expect(firstPassNotifications).toHaveLength(1);
+    expect(secondPassNotifications).toHaveLength(1);
+    expect(secondPassNotifications[0].messageAuthor.id).toBe(
+      messageAuthor.user.id
+    );
+  });
+});


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9351](https://entourage-asso.atlassian.net/browse/EN-9351)
**🚧 PR-Front :** [front/737](https://github.com/ReseauEntourage/entourage-job-front/pull/737)
**💬 Commentaire :**

This pull request introduces a new `unavailableAt` field to the `UserProfiles` table, replacing the previous `isAvailable` boolean throughout the codebase. This change enables more precise tracking of user availability and supports a new daily cron job that sends notification emails to users who sent a single message to someone who became unavailable the previous day. The migration includes a safe backfill to avoid accidental mass notifications, and all relevant DTOs, queries, and services have been updated to use the new field.

**Database and Data Model Changes:**

* Added a nullable `unavailableAt` column to the `UserProfiles` table, with a migration to backfill existing unavailable users with a date outside the notification window to prevent accidental emails. (`src/db/migrations/20260803000000-add-unavailable-at-to-user-profiles.js` [[1]](diffhunk://#diff-41753fabbd5f587256ea2ba679356f67b1f96cbf84f9ebf5e1f0b75ff342c70cR1-R14) `src/db/migrations/20260803000001-backfill-unavailable-at-on-user-profiles.js` [[2]](diffhunk://#diff-f8f01d1be80640ecb136ca7593ec5cc0a45d365b827c3f7a1bcd81d6769ec8e5R1-R28)
* Replaced all uses of the `isAvailable` field with `unavailableAt` in DTOs, attributes, and query logic. (`src/current-user/dto/current-user-profile.dto.ts` [[1]](diffhunk://#diff-21ea24ec6813a7d4a6d286a6a37d02fc78ff0c81e97a8784ba079435e9c2c249L15-R15) [[2]](diffhunk://#diff-21ea24ec6813a7d4a6d286a6a37d02fc78ff0c81e97a8784ba079435e9c2c249L32-R32) [[3]](diffhunk://#diff-21ea24ec6813a7d4a6d286a6a37d02fc78ff0c81e97a8784ba079435e9c2c249L60-R60) [[4]](diffhunk://#diff-21ea24ec6813a7d4a6d286a6a37d02fc78ff0c81e97a8784ba079435e9c2c249L82-R82) `src/companies/companies.includes.ts` [[5]](diffhunk://#diff-79c25720da2e4289df972dfb66cdc765c05807a0e7e78c91647855606d98fe52L53-R53) `src/messaging/messaging.attributes.ts` [[6]](diffhunk://#diff-176273e71aeefcbf6d9b4a6c5cc99cdbbef0293a3d275e03fe8f402b5e221d18L24-R24) `src/user-profiles/dto/create-candidate-user-profile.dto.ts` [[7]](diffhunk://#diff-56196fefd34c4c6ab1d1ce2b7d3029f46278fdb696521c193bad2c60e79e58b5L8-R8) `src/user-profiles/dto/create-coach-user-profile.dto.ts` [[8]](diffhunk://#diff-a129835a6815815bc43e50b21c565b66a15b9004190ea59ec7bf5aca1c2062e0L10-R10) `src/user-profiles/dto/public-profile.dto.ts` [[9]](diffhunk://#diff-488e4b65b6855ae5314e70d40e967eec1a9fd36d85b573810904e4896d0fcf61L38) [[10]](diffhunk://#diff-488e4b65b6855ae5314e70d40e967eec1a9fd36d85b573810904e4896d0fcf61R46)

**Business Logic and Query Updates:**

* Updated all queries, filters, and recommendation logic to use `unavailableAt` for availability checks instead of `isAvailable`. (`src/messaging/messaging.service.ts` [[1]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61L1253-R1253) `src/user-profile-recommendations/user-profile-recommendations-ai.service.ts` [[2]](diffhunk://#diff-68cb40add3dbc34f676bde8ac9fc7502cc44bb92eb943193e751a8162dcbd290L216-R218) [[3]](diffhunk://#diff-68cb40add3dbc34f676bde8ac9fc7502cc44bb92eb943193e751a8162dcbd290L264-R266) [[4]](diffhunk://#diff-68cb40add3dbc34f676bde8ac9fc7502cc44bb92eb943193e751a8162dcbd290L589-R589) `src/user-profile-recommendations/user-profile-recommendations-legacy.service.ts` [[5]](diffhunk://#diff-6648e6d41c3299ae1f7ac1c6eb5ff0170f61a696f6dd39ee760c5215dfc5cd4cL125-R125)

**Notification Email Feature:**

* Added a daily cron job at 9 AM that finds users who sent a single, unanswered message to someone who became unavailable the previous day, and sends them a notification email using a new Mailjet template. (`src/cron/cron.service.ts` [[1]](diffhunk://#diff-c18c1daa9d1e2493a2b92cec33b01be231319467e4a19bc9436a154f9cd33a87R392-R411) `src/external-services/mailjet/mailjet.types.ts` [[2]](diffhunk://#diff-cfcacc26ace1fbb6594c46dc3fc54867d1811784c3ee3ed4eae0fe485f7d171bR158) `src/mails/mails.service.ts` [[3]](diffhunk://#diff-a897829bc6ed86b52d1a7336116247008ac1a0936ee9520feec464a6d063f94aR592-R626) `src/queues/consumers/cron-tasks/cron-tasks.processor.ts` [[4]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7R23-R24) [[5]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7R98-R99) [[6]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7R1318-R1377) `src/queues/queues.types.ts` [[7]](diffhunk://#diff-ee8906796eb8b13aa925c36b66cbed2820293546896af3a6f02656cad1e420aaR71-R72) [[8]](diffhunk://#diff-ee8906796eb8b13aa925c36b66cbed2820293546896af3a6f02656cad1e420aaR124) [[9]](diffhunk://#diff-ee8906796eb8b13aa925c36b66cbed2820293546896af3a6f02656cad1e420aaR264-R268)

**Documentation and Testing:**

* Added documentation to clarify the correct way to run e2e tests to avoid accidental data loss, and emphasized the importance of not running destructive commands against the wrong database. (`CLAUDE.md` [CLAUDE.mdR61-R93](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R61-R93))

[EN-9351]: https://entourage-asso.atlassian.net/browse/EN-9351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ