### PR TITLE
Add mirror role participants count and update related services

### DIFF
--- a/src/current-user/current-user.service.ts
+++ b/src/current-user/current-user.service.ts
@@ -133,10 +133,15 @@ export class CurrentUserService {
       averageDelayResponse,
       responseRate,
       totalConversationWithMirrorRoleCount,
+      availableMirrorRoleParticipantsCount,
     ] = await Promise.all([
       this.usersStatsService.getAverageDelayResponse(userId),
       this.usersStatsService.getResponseRate(userId),
       this.usersStatsService.getTotalConversationWithMirrorRoleCount(
+        userId,
+        userRole
+      ),
+      this.usersStatsService.getAvailableMirrorRoleParticipantsCount(
         userId,
         userRole
       ),
@@ -147,6 +152,7 @@ export class CurrentUserService {
       averageDelayResponse,
       responseRate,
       totalConversationWithMirrorRoleCount,
+      availableMirrorRoleParticipantsCount,
     };
   }
 

--- a/src/current-user/dto/current-user-stats.dto.ts
+++ b/src/current-user/dto/current-user-stats.dto.ts
@@ -1,4 +1,5 @@
 export interface CurrentUserStatsDto {
+  availableMirrorRoleParticipantsCount: number | null;
   averageDelayResponse: number | null;
   createdAt: Date;
   responseRate: number | null;

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -12,6 +12,7 @@ import { MediasService } from 'src/medias/medias.service';
 import { Media } from 'src/medias/models';
 import { QueuesService } from 'src/queues/producers/queues.service';
 import { Jobs } from 'src/queues/queues.types';
+import { UserProfile } from 'src/user-profiles/models';
 import { User } from 'src/users/models';
 import { UsersService } from 'src/users/users.service';
 import { UserRole, UserRoles } from 'src/users/users.types';
@@ -763,20 +764,22 @@ export class MessagingService {
   }
 
   /**
-   * Returns the number of conversations within a given time window where:
+   * Returns the number of direct conversations within a given time window where:
    * - All participants have sent at least one message (mutual exchange)
    * - The conversation has mirror roles: at least one CANDIDATE and at least one COACH/REFERER
-   *   (group conversations with multiple candidates or coaches/referers are included)
    * - No ADMIN participant is involved
+   * - Group conversations are excluded
    *
    * @param userId - The ID of the user to count conversations for
    * @param delayMonths - How far back to look, in months (ignored if not provided, meaning all conversations are considered)
+   * @param onlyAvailableMirrorParticipant - When true, only count conversations whose mirror role participant is available
    * @returns The count of mirror role conversations with mutual exchange for the user within the specified time window
    */
   async getMirrorRoleConversationCount(
     userId: string,
     userRole: UserRole,
-    delayMonths?: number
+    delayMonths?: number,
+    onlyAvailableMirrorParticipant?: boolean
   ): Promise<number> {
     const mirrorRole = await this.usersService.getUserMirrorRole(userRole);
     const createdAtFilter =
@@ -797,6 +800,7 @@ export class MessagingService {
         {
           model: Conversation,
           as: 'conversation',
+          where: { type: ConversationType.DIRECT },
           include: [
             {
               model: Message,
@@ -808,6 +812,14 @@ export class MessagingService {
               as: 'participants',
               attributes: ['id', 'role'],
               paranoid: false,
+              include: onlyAvailableMirrorParticipant
+                ? [
+                    {
+                      model: UserProfile,
+                      attributes: ['isAvailable'],
+                    },
+                  ]
+                : [],
             },
           ],
         },
@@ -837,6 +849,14 @@ export class MessagingService {
         messages.some((m) => m.authorId === participantId)
       );
       if (!allParticipantsReplied) continue;
+
+      // Restrict to conversations whose mirror role participant is available
+      if (onlyAvailableMirrorParticipant) {
+        const mirrorParticipant = participants.find(
+          (p) => p.role === mirrorRole
+        );
+        if (!mirrorParticipant?.userProfile?.isAvailable) continue;
+      }
 
       count++;
     }

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -817,7 +817,7 @@ export class MessagingService {
                     {
                       model: UserProfile,
                       as: 'userProfile',
-                      attributes: ['isAvailable'],
+                      attributes: ['unavailableAt'],
                     },
                   ]
                 : [],
@@ -856,7 +856,7 @@ export class MessagingService {
         const mirrorParticipant = participants.find(
           (p) => p.role === mirrorRole
         );
-        if (!mirrorParticipant?.userProfile?.isAvailable) continue;
+        if (mirrorParticipant?.userProfile?.unavailableAt) continue;
       }
 
       count++;

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -816,6 +816,7 @@ export class MessagingService {
                 ? [
                     {
                       model: UserProfile,
+                      as: 'userProfile',
                       attributes: ['isAvailable'],
                     },
                   ]

--- a/src/user-profiles/dto/public-profile.dto.ts
+++ b/src/user-profiles/dto/public-profile.dto.ts
@@ -17,6 +17,7 @@ import { ZoneName } from 'src/utils/types/zones.types';
 
 export type PublicProfileDto = {
   achievements: UserAchievement[];
+  availableMirrorRoleParticipantsCount?: number | null;
   averageDelayResponse?: number | null;
   company: Partial<Company> | null;
   contracts: Contract[];
@@ -55,6 +56,7 @@ export const generatePublicProfileDto = (
     averageDelayResponse: number | null;
     responseRate: number | null;
     totalConversationWithMirrorRoleCount: number | null;
+    availableMirrorRoleParticipantsCount: number | null;
   }
 ): PublicProfileDto => {
   const dto = {
@@ -96,6 +98,8 @@ export const generatePublicProfileDto = (
     dto.averageDelayResponse = usersStats.averageDelayResponse;
     dto.totalConversationWithMirrorRoleCount =
       usersStats.totalConversationWithMirrorRoleCount;
+    dto.availableMirrorRoleParticipantsCount =
+      usersStats.availableMirrorRoleParticipantsCount;
   }
   return dto;
 };

--- a/src/user-profiles/user-profiles.service.ts
+++ b/src/user-profiles/user-profiles.service.ts
@@ -1093,21 +1093,34 @@ export class UserProfilesService {
     );
   }
 
+  async getAvailableMirrorRoleParticipantsCount(
+    userId: string,
+    userRole: UserRole
+  ): Promise<number> {
+    return this.usersStatsService.getAvailableMirrorRoleParticipantsCount(
+      userId,
+      userRole
+    );
+  }
+
   async getUsersStats(userId: string, userRole: UserRole) {
     const [
       averageDelayResponse,
       responseRate,
       totalConversationWithMirrorRoleCount,
+      availableMirrorRoleParticipantsCount,
     ] = await Promise.all([
       this.userProfileAnalyticsService.getAverageDelayResponse(userId),
       this.userProfileAnalyticsService.getResponseRate(userId),
       this.getTotalConversationWithMirrorRoleCount(userId, userRole),
+      this.getAvailableMirrorRoleParticipantsCount(userId, userRole),
     ]);
 
     return {
       averageDelayResponse,
       responseRate,
       totalConversationWithMirrorRoleCount,
+      availableMirrorRoleParticipantsCount,
     };
   }
 

--- a/src/users-stats/users-stats.service.ts
+++ b/src/users-stats/users-stats.service.ts
@@ -26,4 +26,16 @@ export class UsersStatsService {
       userRole
     );
   }
+
+  async getAvailableMirrorRoleParticipantsCount(
+    userId: string,
+    userRole: UserRole
+  ) {
+    return this.messagingService.getMirrorRoleConversationCount(
+      userId,
+      userRole,
+      undefined,
+      true
+    );
+  }
 }

--- a/tests/messaging/messaging.e2e-spec.ts
+++ b/tests/messaging/messaging.e2e-spec.ts
@@ -1240,7 +1240,7 @@ describe('MESSAGING', () => {
     it('should count an available mirror role participant when onlyAvailableMirrorParticipant is true', async () => {
       const availableCoach = await usersHelper.createLoggedInUser(
         { role: UserRoles.COACH },
-        { userProfile: { isAvailable: true } }
+        { userProfile: { unavailableAt: null } }
       );
       const conversation = await conversationFactory.create({
         type: ConversationType.DIRECT,
@@ -1272,7 +1272,7 @@ describe('MESSAGING', () => {
     it('should exclude an unavailable mirror role participant when onlyAvailableMirrorParticipant is true', async () => {
       const unavailableCoach = await usersHelper.createLoggedInUser(
         { role: UserRoles.COACH },
-        { userProfile: { isAvailable: false } }
+        { userProfile: { unavailableAt: new Date() } }
       );
       const conversation = await conversationFactory.create({
         type: ConversationType.DIRECT,

--- a/tests/messaging/messaging.e2e-spec.ts
+++ b/tests/messaging/messaging.e2e-spec.ts
@@ -5,6 +5,7 @@ import { UsersHelper, LoggedInUser } from '../users/users.helper';
 import { SlackService } from 'src/external-services/slack/slack.service';
 import { MessagingController } from 'src/messaging/messaging.controller';
 import { MessagingService } from 'src/messaging/messaging.service';
+import { ConversationType } from 'src/messaging/models/conversation.model';
 import { QueuesService } from 'src/queues/producers/queues.service';
 import { User } from 'src/users/models';
 import { UserRoles } from 'src/users/users.types';
@@ -1172,6 +1173,132 @@ describe('MESSAGING', () => {
           });
 
       expect(response.status).toBe(400);
+    });
+  });
+
+  describe('getMirrorRoleConversationCount', () => {
+    it('should not count a group conversation with mutual exchange and a mirror role participant', async () => {
+      const conversation = await conversationFactory.create({
+        type: ConversationType.GROUP,
+      });
+
+      await messagingHelper.associationParticipantsToConversation(
+        conversation.id,
+        [
+          loggedInCandidate.user.id,
+          loggedInCoach.user.id,
+          loggedInOtherCandidate.user.id,
+        ]
+      );
+      await messagingHelper.createMessage(
+        conversation.id,
+        loggedInCandidate.user.id
+      );
+      await messagingHelper.createMessage(
+        conversation.id,
+        loggedInCoach.user.id
+      );
+      await messagingHelper.createMessage(
+        conversation.id,
+        loggedInOtherCandidate.user.id
+      );
+
+      const count = await messagingService.getMirrorRoleConversationCount(
+        loggedInCandidate.user.id,
+        UserRoles.CANDIDATE
+      );
+
+      expect(count).toBe(0);
+    });
+
+    it('should count a direct conversation with mutual exchange and a mirror role participant', async () => {
+      const conversation = await conversationFactory.create({
+        type: ConversationType.DIRECT,
+      });
+
+      await messagingHelper.associationParticipantsToConversation(
+        conversation.id,
+        [loggedInCandidate.user.id, loggedInCoach.user.id]
+      );
+      await messagingHelper.createMessage(
+        conversation.id,
+        loggedInCandidate.user.id
+      );
+      await messagingHelper.createMessage(
+        conversation.id,
+        loggedInCoach.user.id
+      );
+
+      const count = await messagingService.getMirrorRoleConversationCount(
+        loggedInCandidate.user.id,
+        UserRoles.CANDIDATE
+      );
+
+      expect(count).toBe(1);
+    });
+
+    it('should count an available mirror role participant when onlyAvailableMirrorParticipant is true', async () => {
+      const availableCoach = await usersHelper.createLoggedInUser(
+        { role: UserRoles.COACH },
+        { userProfile: { isAvailable: true } }
+      );
+      const conversation = await conversationFactory.create({
+        type: ConversationType.DIRECT,
+      });
+
+      await messagingHelper.associationParticipantsToConversation(
+        conversation.id,
+        [loggedInCandidate.user.id, availableCoach.user.id]
+      );
+      await messagingHelper.createMessage(
+        conversation.id,
+        loggedInCandidate.user.id
+      );
+      await messagingHelper.createMessage(
+        conversation.id,
+        availableCoach.user.id
+      );
+
+      const count = await messagingService.getMirrorRoleConversationCount(
+        loggedInCandidate.user.id,
+        UserRoles.CANDIDATE,
+        undefined,
+        true
+      );
+
+      expect(count).toBe(1);
+    });
+
+    it('should exclude an unavailable mirror role participant when onlyAvailableMirrorParticipant is true', async () => {
+      const unavailableCoach = await usersHelper.createLoggedInUser(
+        { role: UserRoles.COACH },
+        { userProfile: { isAvailable: false } }
+      );
+      const conversation = await conversationFactory.create({
+        type: ConversationType.DIRECT,
+      });
+
+      await messagingHelper.associationParticipantsToConversation(
+        conversation.id,
+        [loggedInCandidate.user.id, unavailableCoach.user.id]
+      );
+      await messagingHelper.createMessage(
+        conversation.id,
+        loggedInCandidate.user.id
+      );
+      await messagingHelper.createMessage(
+        conversation.id,
+        unavailableCoach.user.id
+      );
+
+      const count = await messagingService.getMirrorRoleConversationCount(
+        loggedInCandidate.user.id,
+        UserRoles.CANDIDATE,
+        undefined,
+        true
+      );
+
+      expect(count).toBe(0);
     });
   });
 });


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9378](https://entourage-asso.atlassian.net/browse/EN-9378)
**🚧 PR-Front :** [front/738](https://github.com/ReseauEntourage/entourage-job-front/pull/738)
**💬 Commentaire :**

This pull request introduces a new feature to count the number of direct conversations with available mirror role participants and exposes this information in user statistics and public profiles. It also ensures that only direct (not group) conversations are counted for mirror role statistics, and adds comprehensive tests to verify these behaviors.

**Enhancements to user statistics and profiles:**
- Added `availableMirrorRoleParticipantsCount` to the user statistics DTO (`CurrentUserStatsDto`) and public profile DTO, making this data available via relevant service methods and API responses. [[1]](diffhunk://#diff-cdef6afb4f13a98dbf842a59db403899a5e8dc18eabfce2b55f33cbe3cd29da1R2) [[2]](diffhunk://#diff-488e4b65b6855ae5314e70d40e967eec1a9fd36d85b573810904e4896d0fcf61R20) [[3]](diffhunk://#diff-488e4b65b6855ae5314e70d40e967eec1a9fd36d85b573810904e4896d0fcf61R59) [[4]](diffhunk://#diff-488e4b65b6855ae5314e70d40e967eec1a9fd36d85b573810904e4896d0fcf61R101-R102) [[5]](diffhunk://#diff-49e0bbd84e34e56547d71cd99d39000997aca10ac75b02fb73697618989de415R136-R155) [[6]](diffhunk://#diff-68a3f696de85f42a907de2fdfb124fc1cf7b5460e867943e1bc7f00f30ba4648R1096-R1123)
- Updated `CurrentUserService`, `UserProfilesService`, and `UsersStatsService` to compute and return this new statistic. [[1]](diffhunk://#diff-49e0bbd84e34e56547d71cd99d39000997aca10ac75b02fb73697618989de415R136-R155) [[2]](diffhunk://#diff-68a3f696de85f42a907de2fdfb124fc1cf7b5460e867943e1bc7f00f30ba4648R1096-R1123) [[3]](diffhunk://#diff-ee14d0109cf9e1deb0fdae1383e04ae64c4815c7229e43126e404e6d5a81a2daR29-R40)

**Messaging logic improvements:**
- Modified `MessagingService.getMirrorRoleConversationCount` to:
  - Only count direct conversations (excluding group conversations) for mirror role statistics. [[1]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61L766-R782) [[2]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61R803)
  - Add an `onlyAvailableMirrorParticipant` flag to count only conversations where the mirror role participant is available. [[1]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61L766-R782) [[2]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61R815-R822) [[3]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61R853-R860)

**Testing:**
- Added end-to-end tests to verify:
  - Group conversations are not counted for mirror role statistics.
  - Only available mirror role participants are counted when the flag is enabled.
  - Unavailable mirror role participants are excluded when the flag is enabled.

These changes improve the accuracy and usefulness of user statistics by focusing on meaningful direct interactions and reflecting participant availability.

[EN-9378]: https://entourage-asso.atlassian.net/browse/EN-9378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ