### PR TITLE
Enhance automatic user inaccessibility management with role thresholds

### DIFF
--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -1259,8 +1259,8 @@ export class MessagingService {
    * `daysWithoutConnection` days AND have at least one unread conversation message
    * that is older than `daysWithUnreadMessage` days.
    *
-   * `roles` restricts the query to a specific role profile (e.g. Candidat-only
-   * with tightened thresholds, or Coach+Prescripteur with the default ones) so
+   * `roles` restricts the query to a specific role profile (e.g. Candidate-only
+   * with tightened thresholds, or Coach+Referer with the default ones) so
    * that callers can apply different thresholds per role.
    *
    * These users are eligible for automatic unavailability.

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -1259,11 +1259,16 @@ export class MessagingService {
    * `daysWithoutConnection` days AND have at least one unread conversation message
    * that is older than `daysWithUnreadMessage` days.
    *
+   * `roles` restricts the query to a specific role profile (e.g. Candidat-only
+   * with tightened thresholds, or Coach+Prescripteur with the default ones) so
+   * that callers can apply different thresholds per role.
+   *
    * These users are eligible for automatic unavailability.
    */
   async getInactiveUsersWithUnreadConversations(
     daysWithoutConnection: number,
-    daysWithUnreadMessage: number
+    daysWithUnreadMessage: number,
+    roles: UserRole[]
   ): Promise<{ id: string }[]> {
     return this.conversationModel.sequelize.query(
       `
@@ -1273,7 +1278,7 @@ export class MessagingService {
       WHERE
         up."unavailableAt" IS NULL
         AND u."deletedAt" IS NULL
-        AND u.role NOT IN (:adminRole)
+        AND u.role IN (:roles)
         AND u."lastConnection" < NOW() - make_interval(days => :daysWithoutConnection)
         AND EXISTS (
           SELECT 1
@@ -1293,7 +1298,7 @@ export class MessagingService {
         replacements: {
           daysWithoutConnection,
           daysWithUnreadMessage,
-          adminRole: [UserRoles.ADMIN],
+          roles,
         },
       }
     );

--- a/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
+++ b/src/queues/consumers/cron-tasks/cron-tasks.processor.ts
@@ -599,18 +599,28 @@ export class CronTasksProcessor extends WorkerHost {
   }
 
   async prepareAutoSetUnavailableUsers() {
-    const DAYS_WITHOUT_CONNECTION = 60;
-    const DAYS_WITH_UNREAD_MESSAGE = 30;
+    const CANDIDATE_DAYS_WITHOUT_CONNECTION = 30;
+    const CANDIDATE_DAYS_WITH_UNREAD_MESSAGE = 15;
+    const DEFAULT_DAYS_WITHOUT_CONNECTION = 60;
+    const DEFAULT_DAYS_WITH_UNREAD_MESSAGE = 30;
 
     this.logger.log(
-      `Setting inactive users as unavailable (no connection since ${DAYS_WITHOUT_CONNECTION} days, unread message since ${DAYS_WITH_UNREAD_MESSAGE} days)...`
+      `Setting inactive users as unavailable (candidates: no connection since ${CANDIDATE_DAYS_WITHOUT_CONNECTION} days, unread message since ${CANDIDATE_DAYS_WITH_UNREAD_MESSAGE} days; others: no connection since ${DEFAULT_DAYS_WITHOUT_CONNECTION} days, unread message since ${DEFAULT_DAYS_WITH_UNREAD_MESSAGE} days)...`
     );
 
-    const inactiveUsersRows =
-      await this.messagingService.getInactiveUsersWithUnreadConversations(
-        DAYS_WITHOUT_CONNECTION,
-        DAYS_WITH_UNREAD_MESSAGE
-      );
+    const [candidateRows, defaultRows] = await Promise.all([
+      this.messagingService.getInactiveUsersWithUnreadConversations(
+        CANDIDATE_DAYS_WITHOUT_CONNECTION,
+        CANDIDATE_DAYS_WITH_UNREAD_MESSAGE,
+        [UserRoles.CANDIDATE]
+      ),
+      this.messagingService.getInactiveUsersWithUnreadConversations(
+        DEFAULT_DAYS_WITHOUT_CONNECTION,
+        DEFAULT_DAYS_WITH_UNREAD_MESSAGE,
+        [UserRoles.COACH, UserRoles.REFERER]
+      ),
+    ]);
+    const inactiveUsersRows = [...candidateRows, ...defaultRows];
 
     this.logger.log(
       `Found ${inactiveUsersRows.length} inactive users to set as unavailable`
@@ -1257,11 +1267,20 @@ export class CronTasksProcessor extends WorkerHost {
   }
 
   async prepareUnavailableUsersMails() {
-    const DAYS_SINCE_LAST_CONVERSATION = 30;
+    const CANDIDATE_DAYS_SINCE_LAST_CONVERSATION = 15;
+    const DEFAULT_DAYS_SINCE_LAST_CONVERSATION = 30;
     this.logger.log('Preparing unavailable users mails...');
-    const rows = await this.usersService.getUserRowsForUnavailableUsers(
-      DAYS_SINCE_LAST_CONVERSATION
-    );
+    const [candidateRows, defaultRows] = await Promise.all([
+      this.usersService.getUserRowsForUnavailableUsers(
+        CANDIDATE_DAYS_SINCE_LAST_CONVERSATION,
+        [UserRoles.CANDIDATE]
+      ),
+      this.usersService.getUserRowsForUnavailableUsers(
+        DEFAULT_DAYS_SINCE_LAST_CONVERSATION,
+        [UserRoles.COACH, UserRoles.REFERER]
+      ),
+    ]);
+    const rows = [...candidateRows, ...defaultRows];
     this.logger.log(
       `Found ${rows.length} users eligible for unavailable reminder`
     );
@@ -1291,7 +1310,7 @@ export class CronTasksProcessor extends WorkerHost {
 
     await this.cronTasksSlackReporterService.sendCronTaskResultToSlack(
       succeeded,
-      `📵 Unavailable users - J+${DAYS_SINCE_LAST_CONVERSATION}`,
+      `📵 Unavailable users - J+${CANDIDATE_DAYS_SINCE_LAST_CONVERSATION}/${DEFAULT_DAYS_SINCE_LAST_CONVERSATION}`,
       {
         total: rows.length,
         success: successIds.length,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1523,15 +1523,21 @@ export class UsersService {
       ) lm ON lm."conversationId" = c.id
       WHERE (cp."seenAt" IS NULL OR lm."lastMessageTime" >= cp."seenAt")
         AND up."unavailableAt" IS NULL
-        AND lm."lastMessageTime" >= CURRENT_TIMESTAMP - INTERVAL '${
-          daysSinceLastConversation + 1
-        } days'
-        AND lm."lastMessageTime" < CURRENT_TIMESTAMP - INTERVAL '${daysSinceLastConversation} days'
+        AND lm."lastMessageTime" >= CURRENT_TIMESTAMP - make_interval(days => :daysSinceLastConversationPlusOne)
+        AND lm."lastMessageTime" < CURRENT_TIMESTAMP - make_interval(days => :daysSinceLastConversation)
         AND u.role IN (:roles)
         AND u."deletedAt" IS NULL
       GROUP BY u.id
       `,
-      { type: QueryTypes.SELECT, raw: true, replacements: { roles } }
+      {
+        type: QueryTypes.SELECT,
+        raw: true,
+        replacements: {
+          roles,
+          daysSinceLastConversation,
+          daysSinceLastConversationPlusOne: daysSinceLastConversation + 1,
+        },
+      }
     );
   }
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1504,7 +1504,8 @@ export class UsersService {
   }
 
   async getUserRowsForUnavailableUsers(
-    daysSinceLastConversation: number
+    daysSinceLastConversation: number,
+    roles: UserRole[]
   ): Promise<{ id: string; unreadConversationsCount: number }[]> {
     return this.userModel.sequelize.query(
       `
@@ -1526,11 +1527,11 @@ export class UsersService {
           daysSinceLastConversation + 1
         } days'
         AND lm."lastMessageTime" < CURRENT_TIMESTAMP - INTERVAL '${daysSinceLastConversation} days'
-        AND u.role != 'Admin'
+        AND u.role IN (:roles)
         AND u."deletedAt" IS NULL
       GROUP BY u.id
       `,
-      { type: QueryTypes.SELECT, raw: true }
+      { type: QueryTypes.SELECT, raw: true, replacements: { roles } }
     );
   }
 

--- a/tests/messaging/auto-unavailable-users.e2e-spec.ts
+++ b/tests/messaging/auto-unavailable-users.e2e-spec.ts
@@ -1,0 +1,143 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MessagingService } from 'src/messaging/messaging.service';
+import { QueuesService } from 'src/queues/producers/queues.service';
+import { UserRoles } from 'src/users/users.types';
+import { CustomTestingModule } from 'tests/custom-testing.module';
+import { DatabaseHelper } from 'tests/database.helper';
+import { QueuesServiceMock } from 'tests/queues/queues.service.mock';
+import { LoggedInUser, UsersHelper } from 'tests/users/users.helper';
+import { ConversationFactory } from './conversation.factory';
+import { MessagingHelper } from './messaging.helper';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const daysAgo = (days: number) => new Date(Date.now() - days * DAY_IN_MS);
+
+describe('AUTO UNAVAILABILITY - INACTIVE USERS WITH UNREAD CONVERSATIONS', () => {
+  let app: INestApplication;
+
+  let databaseHelper: DatabaseHelper;
+  let usersHelper: UsersHelper;
+  let messagingService: MessagingService;
+  let conversationFactory: ConversationFactory;
+  let messagingHelper: MessagingHelper;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [CustomTestingModule],
+    })
+      .overrideProvider(QueuesService)
+      .useClass(QueuesServiceMock)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    databaseHelper = moduleFixture.get<DatabaseHelper>(DatabaseHelper);
+    usersHelper = moduleFixture.get<UsersHelper>(UsersHelper);
+    messagingService = moduleFixture.get<MessagingService>(MessagingService);
+    conversationFactory =
+      moduleFixture.get<ConversationFactory>(ConversationFactory);
+    messagingHelper = moduleFixture.get<MessagingHelper>(MessagingHelper);
+
+    await databaseHelper.resetTestDB();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(async () => {
+    await databaseHelper.resetTestDB();
+  });
+
+  // `inactiveUser` never reads the message; `otherParticipant` is only there
+  // to author it, since `authorId != u.id` is required for it to count as unread.
+  const createInactiveUserWithUnreadMessage = async (
+    inactiveUser: LoggedInUser,
+    unreadMessageAge: number
+  ) => {
+    const otherParticipant = await usersHelper.createLoggedInUser({
+      role: UserRoles.COACH,
+    });
+    const conversation = await conversationFactory.create();
+    await messagingHelper.associationParticipantsToConversation(
+      conversation.id,
+      [inactiveUser.user.id, otherParticipant.user.id]
+    );
+    await messagingHelper.createMessage(
+      conversation.id,
+      otherParticipant.user.id,
+      { createdAt: daysAgo(unreadMessageAge) }
+    );
+  };
+
+  it('matches a candidate inactive for 30 days with a message unread for 15 days', async () => {
+    const candidate = await usersHelper.createLoggedInUser({
+      role: UserRoles.CANDIDATE,
+      lastConnection: daysAgo(30),
+    });
+    await createInactiveUserWithUnreadMessage(candidate, 15);
+
+    const rows = await messagingService.getInactiveUsersWithUnreadConversations(
+      30,
+      15,
+      [UserRoles.CANDIDATE]
+    );
+
+    expect(rows.map((r) => r.id)).toEqual([candidate.user.id]);
+  });
+
+  it('matches a coach inactive for 60 days with a message unread for 30 days', async () => {
+    const coach = await usersHelper.createLoggedInUser({
+      role: UserRoles.COACH,
+      lastConnection: daysAgo(60),
+    });
+    await createInactiveUserWithUnreadMessage(coach, 30);
+
+    const rows = await messagingService.getInactiveUsersWithUnreadConversations(
+      60,
+      30,
+      [UserRoles.COACH, UserRoles.REFERER]
+    );
+
+    expect(rows.map((r) => r.id)).toEqual([coach.user.id]);
+  });
+
+  it('does not match a candidate under the tightened thresholds (45 days without connection but message only 10 days old)', async () => {
+    const candidate = await usersHelper.createLoggedInUser({
+      role: UserRoles.CANDIDATE,
+      lastConnection: daysAgo(45),
+    });
+    await createInactiveUserWithUnreadMessage(candidate, 10);
+
+    const rows = await messagingService.getInactiveUsersWithUnreadConversations(
+      30,
+      15,
+      [UserRoles.CANDIDATE]
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('does not double-count a candidate when the default role profile is queried', async () => {
+    const candidate = await usersHelper.createLoggedInUser({
+      role: UserRoles.CANDIDATE,
+      lastConnection: daysAgo(60),
+    });
+    await createInactiveUserWithUnreadMessage(candidate, 30);
+
+    const candidateRows =
+      await messagingService.getInactiveUsersWithUnreadConversations(30, 15, [
+        UserRoles.CANDIDATE,
+      ]);
+    const defaultRows =
+      await messagingService.getInactiveUsersWithUnreadConversations(60, 30, [
+        UserRoles.COACH,
+        UserRoles.REFERER,
+      ]);
+
+    expect(candidateRows.map((r) => r.id)).toEqual([candidate.user.id]);
+    expect(defaultRows).toHaveLength(0);
+  });
+});

--- a/tests/users/unavailable-users-reminder.e2e-spec.ts
+++ b/tests/users/unavailable-users-reminder.e2e-spec.ts
@@ -1,0 +1,148 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { QueuesService } from 'src/queues/producers/queues.service';
+import { UsersService } from 'src/users/users.service';
+import { UserRoles } from 'src/users/users.types';
+import { CustomTestingModule } from 'tests/custom-testing.module';
+import { DatabaseHelper } from 'tests/database.helper';
+import { ConversationFactory } from 'tests/messaging/conversation.factory';
+import { MessagingHelper } from 'tests/messaging/messaging.helper';
+import { QueuesServiceMock } from 'tests/queues/queues.service.mock';
+import { LoggedInUser, UsersHelper } from './users.helper';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const daysAgo = (days: number) => new Date(Date.now() - days * DAY_IN_MS);
+
+describe('UNAVAILABLE USERS REMINDER MAIL - ELIGIBLE USER ROWS', () => {
+  let app: INestApplication;
+
+  let databaseHelper: DatabaseHelper;
+  let usersHelper: UsersHelper;
+  let usersService: UsersService;
+  let conversationFactory: ConversationFactory;
+  let messagingHelper: MessagingHelper;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [CustomTestingModule],
+    })
+      .overrideProvider(QueuesService)
+      .useClass(QueuesServiceMock)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    databaseHelper = moduleFixture.get<DatabaseHelper>(DatabaseHelper);
+    usersHelper = moduleFixture.get<UsersHelper>(UsersHelper);
+    usersService = moduleFixture.get<UsersService>(UsersService);
+    conversationFactory =
+      moduleFixture.get<ConversationFactory>(ConversationFactory);
+    messagingHelper = moduleFixture.get<MessagingHelper>(MessagingHelper);
+
+    await databaseHelper.resetTestDB();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(async () => {
+    await databaseHelper.resetTestDB();
+  });
+
+  // The recipient never sees the message; `otherParticipant` authors it so
+  // the recipient's `seenAt` (never set) trails the last message. The query
+  // doesn't exclude the author's own participant row (unlike the auto-
+  // unavailability query), so the author's role must fall outside whichever
+  // role filter is under test, or it would also show up in `rows`.
+  const createStillAvailableUserWithUnreadMessage = async (
+    recipient: LoggedInUser,
+    lastMessageAge: number,
+    authorRole: (typeof UserRoles)[keyof typeof UserRoles]
+  ) => {
+    const otherParticipant = await usersHelper.createLoggedInUser({
+      role: authorRole,
+    });
+    const conversation = await conversationFactory.create();
+    await messagingHelper.associationParticipantsToConversation(
+      conversation.id,
+      [recipient.user.id, otherParticipant.user.id]
+    );
+    await messagingHelper.createMessage(
+      conversation.id,
+      otherParticipant.user.id,
+      { createdAt: daysAgo(lastMessageAge) }
+    );
+  };
+
+  it('returns a candidate whose last message is 15 days old', async () => {
+    const candidate = await usersHelper.createLoggedInUser({
+      role: UserRoles.CANDIDATE,
+    });
+    await createStillAvailableUserWithUnreadMessage(
+      candidate,
+      15,
+      UserRoles.COACH
+    );
+
+    const rows = await usersService.getUserRowsForUnavailableUsers(15, [
+      UserRoles.CANDIDATE,
+    ]);
+
+    expect(rows.map((r) => r.id)).toEqual([candidate.user.id]);
+  });
+
+  it('does not return a candidate under the candidate window when queried with the default 30-day window', async () => {
+    const candidate = await usersHelper.createLoggedInUser({
+      role: UserRoles.CANDIDATE,
+    });
+    await createStillAvailableUserWithUnreadMessage(
+      candidate,
+      15,
+      UserRoles.COACH
+    );
+
+    const rows = await usersService.getUserRowsForUnavailableUsers(30, [
+      UserRoles.COACH,
+      UserRoles.REFERER,
+    ]);
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('returns a coach whose last message is 30 days old under the default window', async () => {
+    const coach = await usersHelper.createLoggedInUser({
+      role: UserRoles.COACH,
+    });
+    await createStillAvailableUserWithUnreadMessage(
+      coach,
+      30,
+      UserRoles.CANDIDATE
+    );
+
+    const rows = await usersService.getUserRowsForUnavailableUsers(30, [
+      UserRoles.COACH,
+      UserRoles.REFERER,
+    ]);
+
+    expect(rows.map((r) => r.id)).toEqual([coach.user.id]);
+  });
+
+  it('does not return a coach when queried with the candidate 15-day window', async () => {
+    const coach = await usersHelper.createLoggedInUser({
+      role: UserRoles.COACH,
+    });
+    await createStillAvailableUserWithUnreadMessage(
+      coach,
+      30,
+      UserRoles.CANDIDATE
+    );
+
+    const rows = await usersService.getUserRowsForUnavailableUsers(15, [
+      UserRoles.CANDIDATE,
+    ]);
+
+    expect(rows).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9350](https://entourage-asso.atlassian.net/browse/EN-9350)
**💬 Commentaire :**

This pull request introduces role-based thresholds for determining inactive users and users eligible for unavailable reminders, allowing different inactivity and unread message windows for candidates versus other roles. It also adds comprehensive end-to-end tests to ensure the new logic is correct.

**Role-based inactivity and unavailable user logic:**

* Updated `getInactiveUsersWithUnreadConversations` in `MessagingService` and `getUserRowsForUnavailableUsers` in `UsersService` to accept a `roles` parameter, restricting queries to specific user roles and enabling per-role thresholds. [[1]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61R1262-R1271) [[2]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L1507-R1508)
* Changed SQL queries to use `IN (:roles)` instead of excluding only admins, so only the specified roles are considered. [[1]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61L1276-R1281) [[2]](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577L1529-R1534)
* Refactored `CronTasksProcessor` to call these methods with role-specific thresholds: candidates have shorter inactivity and unread windows (30/15 days), while coaches and referers use the default (60/30 days). [[1]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7L602-R623) [[2]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7L1260-R1283)
* Updated Slack reporting to reflect the new dual-threshold logic.
* Combined results from both role groups to ensure no user is double-counted. [[1]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7L602-R623) [[2]](diffhunk://#diff-08f3c5051c9bf66e8d7304e414d2252a8239056e9d9b7a6ff0b6e5d9bf3500c7L1260-R1283)

**Testing and validation:**

* Added new end-to-end tests for both auto-unavailability and unavailable user reminder queries, verifying correct behavior for each role and threshold. [[1]](diffhunk://#diff-4ca15e88693f4498d2b04242d6cfebc770c7cf50958d083f7a1e3d44217fc42bR1-R143) [[2]](diffhunk://#diff-1440f7323e50f36b391494904835b13d0392d4295cd001eabc15656ec27608e2R1-R148)

[EN-9350]: https://entourage-asso.atlassian.net/browse/EN-9350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ