### PR TITLE
Implement External CV management and update user profile logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,6 @@ jobs:
       OPENAI_API_KEY: ''
       SHORTIO_DOMAIN: test.short.io
       SHORTIO_API_KEY: test_api_key
-      # Fake S3 config: `Media`'s AfterFind hook presigns a URL for every media
-      # it loads, and presigning is pure local crypto — it needs a bucket name
-      # and credentials to be set, but never reaches AWS. Deliberately invalid
-      # so a test that would really call S3 fails instead of hitting a bucket.
       AWSS3_BUCKET_NAME: test-bucket
       AWSS3_IMAGE_DIRECTORY: images/
       AWSS3_FILE_DIRECTORY: files/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,16 @@ jobs:
       OPENAI_API_KEY: ''
       SHORTIO_DOMAIN: test.short.io
       SHORTIO_API_KEY: test_api_key
+      # Fake S3 config: `Media`'s AfterFind hook presigns a URL for every media
+      # it loads, and presigning is pure local crypto — it needs a bucket name
+      # and credentials to be set, but never reaches AWS. Deliberately invalid
+      # so a test that would really call S3 fails instead of hitting a bucket.
+      AWSS3_BUCKET_NAME: test-bucket
+      AWSS3_IMAGE_DIRECTORY: images/
+      AWSS3_FILE_DIRECTORY: files/
+      AWSS3_ID: test-access-key-id
+      AWSS3_SECRET: test-secret-access-key
+      AWSS3_URL: https://test-bucket.s3.eu-west-3.amazonaws.com/
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "db:migrate:undo": "sequelize db:migrate:undo",
     "db:seed": "sequelize db:seed:all",
     "db:dump": "./dump-db-schema.sh",
+    "script:migrate-external-cvs": "node dist/scripts/migrate-external-cvs",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/src/db/migrations/20260806000000-create-external-cvs.js
+++ b/src/db/migrations/20260806000000-create-external-cvs.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('ExternalCvs', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: () => uuidv4(),
+        primaryKey: true,
+        allowNull: false,
+      },
+      userProfileId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'UserProfiles', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      mediaId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'Medias', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+      deletedAt: { allowNull: true, type: Sequelize.DATE },
+    });
+
+    // Supports the "current CV" lookup:
+    // WHERE userProfileId = ? AND deletedAt IS NULL ORDER BY createdAt DESC
+    await queryInterface.addIndex('ExternalCvs', [
+      'userProfileId',
+      'deletedAt',
+      'createdAt',
+    ]);
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('ExternalCvs');
+  },
+};

--- a/src/db/migrations/20260806000001-add-deleted-at-to-medias.js
+++ b/src/db/migrations/20260806000001-add-deleted-at-to-medias.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // `Medias` had no soft-delete marker: a media row could only be hard-deleted,
+    // which left no trace of the S3 object having been removed. `deletedAt` is
+    // domain-agnostic here — it means "the underlying S3 object is gone".
+    await queryInterface.addColumn('Medias', 'deletedAt', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('Medias', 'deletedAt');
+  },
+};

--- a/src/external-cvs/external-cvs.controller.ts
+++ b/src/external-cvs/external-cvs.controller.ts
@@ -44,11 +44,13 @@ export class ExternalCvsController {
     }
 
     try {
-      const externalCvS3 = await this.externalCvsService.uploadExternalCV(
+      const externalCv = await this.externalCvsService.uploadExternalCV(
         userId,
         file
       );
-      const cvFile = await this.externalCvsService.findExternalCv(externalCvS3);
+      const cvFile = await this.externalCvsService.getExternalCvSignedUrl(
+        externalCv.media
+      );
       return { url: cvFile };
     } catch {
       throw new InternalServerErrorException();
@@ -68,11 +70,14 @@ export class ExternalCvsController {
     if (!userProfile) {
       throw new InternalServerErrorException();
     }
-    if (!userProfile.hasExternalCv) {
+    const externalCv = await this.externalCvsService.findCurrentExternalCv(
+      userProfile.id
+    );
+    if (!externalCv) {
       throw new NotFoundException();
     }
-    const cvFile = await this.externalCvsService.findExternalCv(
-      `files/external-cvs/${userId}.pdf`
+    const cvFile = await this.externalCvsService.getExternalCvSignedUrl(
+      externalCv.media
     );
     return { url: cvFile };
   }

--- a/src/external-cvs/external-cvs.module.ts
+++ b/src/external-cvs/external-cvs.module.ts
@@ -2,14 +2,16 @@ import { Module } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { AWSModule } from 'src/external-services/aws/aws.module';
 import { OpenAiModule } from 'src/external-services/openai/openai.module';
+import { Media } from 'src/medias/models';
 import { UserProfilesModule } from 'src/user-profiles/user-profiles.module';
 import { ExternalCvsController } from './external-cvs.controller';
 import { ExternalCvsService } from './external-cvs.service';
+import { ExternalCv } from './models/external-cv.model';
 import { ExtractedCVData } from './models/extracted-cv-data.model';
 
 @Module({
   imports: [
-    SequelizeModule.forFeature([ExtractedCVData]),
+    SequelizeModule.forFeature([ExtractedCVData, ExternalCv, Media]),
     UserProfilesModule,
     AWSModule,
     OpenAiModule,

--- a/src/external-cvs/external-cvs.service.ts
+++ b/src/external-cvs/external-cvs.service.ts
@@ -1,10 +1,40 @@
 import fs from 'fs';
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
-import { S3File, S3Service } from 'src/external-services/aws/s3.service';
+import { v4 as uuid } from 'uuid';
+import { S3Service } from 'src/external-services/aws/s3.service';
 import { OpenAiService } from 'src/external-services/openai/openai.service';
+import { Media } from 'src/medias/models';
 import { UserProfilesService } from 'src/user-profiles/user-profiles.service';
+import { ExternalCv } from './models/external-cv.model';
 import { ExtractedCVData } from './models/extracted-cv-data.model';
+
+const DEFAULT_CV_FILE_NAME = 'cv.pdf';
+
+/**
+ * Builds the `Content-Disposition` that makes the browser save the file under
+ * the name the candidate uploaded it with, instead of deriving it from the S3
+ * key (`{userId}_{uuid}.pdf`).
+ *
+ * Two forms are emitted, as per RFC 6266: `filename` is an ASCII-only fallback
+ * for clients that ignore the extended form, and `filename*` (RFC 5987) is the
+ * real name — accents are common in French file names and would otherwise be
+ * mangled.
+ */
+const buildAttachmentDisposition = (fileName: string) => {
+  const name = fileName?.trim() || DEFAULT_CV_FILE_NAME;
+  // Drop anything outside printable ASCII, then the characters that would
+  // close the quoted string early.
+  const asciiFallback =
+    name
+      .replace(/[^\x20-\x7e]/g, '_')
+      .replace(/["\\]/g, '')
+      .trim() || DEFAULT_CV_FILE_NAME;
+
+  return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodeURIComponent(
+    name
+  )}`;
+};
 
 @Injectable()
 export class ExternalCvsService {
@@ -13,40 +43,66 @@ export class ExternalCvsService {
     private userProfileService: UserProfilesService,
     private openAiService: OpenAiService,
     @InjectModel(ExtractedCVData)
-    private extractedCVDataModel: typeof ExtractedCVData
+    private extractedCVDataModel: typeof ExtractedCVData,
+    @InjectModel(ExternalCv)
+    private externalCvModel: typeof ExternalCv,
+    @InjectModel(Media)
+    private mediaModel: typeof Media
   ) {}
 
   /**
-   * Uploads an external CV for a user
+   * Uploads an external CV for a user.
+   *
+   * Each upload writes a brand new S3 object under a unique key and registers
+   * it as a new `Media` + `ExternalCv` pair: no previous version is ever
+   * overwritten, deleted or soft-deleted.
+   *
    * @param userId - The ID of the user
    * @param file - The file to be uploaded
-   * @returns {Promise<string>} - The S3 key of the uploaded file
+   * @returns {Promise<ExternalCv>} - The created link, with its media loaded
    */
   async uploadExternalCV(
     userId: string,
     file: Express.Multer.File
-  ): Promise<string> {
+  ): Promise<ExternalCv> {
     const { path } = file;
-    let uploadedCV: S3File;
 
     try {
-      uploadedCV = await this.s3Service.upload(
-        fs.readFileSync(path),
-        'application/pdf',
-        `external-cvs/${userId}.pdf`
-      );
-      await this.userProfileService.updateByUserId(userId, {
-        hasExternalCv: true,
-      });
-
       const userProfile = await this.userProfileService.findOneByUserId(
         userId,
         false
       );
+      if (!userProfile) {
+        throw new InternalServerErrorException();
+      }
+
+      const uploadedCV = await this.s3Service.upload(
+        fs.readFileSync(path),
+        'application/pdf',
+        `external-cvs/${userId}_${uuid()}.pdf`
+      );
+
+      const media = await this.mediaModel.create({
+        name: file.originalname ?? 'cv.pdf',
+        s3Key: uploadedCV.key,
+        mimeType: 'application/pdf',
+        size: file.size,
+        userId,
+      });
+
+      const externalCv = await this.externalCvModel.create({
+        userProfileId: userProfile.id,
+        mediaId: media.id,
+      });
+      externalCv.media = media;
+
+      // The extracted data is profile-scoped and always describes the current
+      // CV, so it is dropped as soon as a new CV becomes the current one.
       await this.extractedCVDataModel.destroy({
         where: { userProfileId: userProfile.id },
       });
-      return uploadedCV.key;
+
+      return externalCv;
     } catch {
       throw new InternalServerErrorException();
     } finally {
@@ -57,18 +113,60 @@ export class ExternalCvsService {
   }
 
   /**
-   * Finds the external CV of a user
-   * @param key - The s3 key of the external CV
-   * @returns {Promise<string | null>} - The signed URL of the external CV
+   * Finds the current external CV of a profile: the most recently created
+   * link that has not been soft-deleted.
+   *
+   * @param userProfileId - The ID of the user profile
+   * @returns {Promise<ExternalCv | null>} - The link, with its media loaded
    */
-  async findExternalCv(key: string) {
+  async findCurrentExternalCv(
+    userProfileId: string
+  ): Promise<ExternalCv | null> {
+    return this.externalCvModel.findOne({
+      where: { userProfileId },
+      order: [['createdAt', 'DESC']],
+      include: [{ model: Media, as: 'media' }],
+    });
+  }
+
+  /**
+   * Finds the current external CV of a user.
+   *
+   * @param userId - The ID of the user
+   * @returns {Promise<ExternalCv | null>} - The link, with its media loaded
+   */
+  async findCurrentExternalCvByUserId(
+    userId: string
+  ): Promise<ExternalCv | null> {
+    const userProfile = await this.userProfileService.findOneByUserId(
+      userId,
+      false
+    );
+    if (!userProfile) {
+      return null;
+    }
+    return this.findCurrentExternalCv(userProfile.id);
+  }
+
+  /**
+   * Builds a signed download URL for a CV media, from the key stored in
+   * database — no key is ever reconstructed. The file is served back under the
+   * name the candidate uploaded it with, not under its S3 key.
+   *
+   * @param media - The media holding the CV file
+   * @returns {Promise<string | null>} - The signed URL, or null if the object is gone
+   */
+  async getExternalCvSignedUrl(media: Media): Promise<string | null> {
+    if (!media) {
+      return null;
+    }
     try {
-      const pdfExists = await this.s3Service.getHead(key);
+      const pdfExists = await this.s3Service.getHead(media.s3Key);
       if (pdfExists) {
         return this.s3Service.getSignedUrl(
-          key,
+          media.s3Key,
           'application/pdf',
-          'attachment'
+          buildAttachmentDisposition(media.name)
         );
       }
       return null;
@@ -78,13 +176,77 @@ export class ExternalCvsService {
   }
 
   /**
-   * Deletes the external CV of a user
+   * Removes the external CV of a user.
+   *
+   * Every still-active link of the profile is soft-deleted — not only the most
+   * recent one — so that no older version can resurface as the current CV.
+   * Neither the `Media` rows nor the S3 objects are touched.
+   *
    * @param userId - The ID of the user
    * @returns {Promise<void>}
    */
   async deleteExternalCv(userId: string) {
-    await this.userProfileService.updateByUserId(userId, {
-      hasExternalCv: false,
+    const userProfile = await this.userProfileService.findOneByUserId(
+      userId,
+      false
+    );
+    if (!userProfile) {
+      return;
+    }
+    await this.externalCvModel.destroy({
+      where: { userProfileId: userProfile.id },
+    });
+  }
+
+  /**
+   * Erases every CV a user ever uploaded, for account deletion.
+   *
+   * Already soft-deleted links are included on purpose: removing a CV from a
+   * profile never deletes the S3 object, so those files are still there.
+   *
+   * Both sides of the soft-delete invariant are recorded explicitly:
+   * `Media.deletedAt` (the S3 object is really gone) and `ExternalCv.deletedAt`
+   * (a link must never outlive its file) — neither is inferred from the
+   * profile's own soft-delete.
+   *
+   * @param userId - The ID of the user whose account is being deleted
+   * @returns {Promise<void>}
+   */
+  async deleteAllExternalCvsForUser(userId: string) {
+    const userProfile = await this.userProfileService.findOneByUserId(
+      userId,
+      false
+    );
+    if (!userProfile) {
+      return;
+    }
+
+    const externalCvs = await this.externalCvModel.findAll({
+      where: { userProfileId: userProfile.id },
+      paranoid: false,
+      include: [{ model: Media, as: 'media', paranoid: false }],
+    });
+
+    if (externalCvs.length === 0) {
+      return;
+    }
+
+    const mediaIds = [...new Set(externalCvs.map(({ mediaId }) => mediaId))];
+    const s3Keys = [
+      ...new Set(
+        externalCvs
+          .map(({ media }) => media?.s3Key)
+          .filter((s3Key): s3Key is string => !!s3Key)
+      ),
+    ];
+
+    if (s3Keys.length > 0) {
+      await this.s3Service.deleteFiles(s3Keys);
+    }
+
+    await this.mediaModel.destroy({ where: { id: mediaIds } });
+    await this.externalCvModel.destroy({
+      where: { userProfileId: userProfile.id },
     });
   }
 }

--- a/src/external-cvs/external-cvs.service.ts
+++ b/src/external-cvs/external-cvs.service.ts
@@ -116,17 +116,27 @@ export class ExternalCvsService {
    * Finds the current external CV of a profile: the most recently created
    * link that has not been soft-deleted.
    *
+   * If that link's media is gone (its S3 object was deleted), the profile has
+   * no current CV: resolution deliberately does NOT fall back to an older
+   * version. Once a new CV is uploaded the previous ones are history only —
+   * the same rule that makes `deleteExternalCv` soft-delete every link rather
+   * than just the latest one.
+   *
+   * The caller therefore gets either a record with a usable `media`, or null.
+   *
    * @param userProfileId - The ID of the user profile
    * @returns {Promise<ExternalCv | null>} - The link, with its media loaded
    */
   async findCurrentExternalCv(
     userProfileId: string
   ): Promise<ExternalCv | null> {
-    return this.externalCvModel.findOne({
+    const externalCv = await this.externalCvModel.findOne({
       where: { userProfileId },
       order: [['createdAt', 'DESC']],
       include: [{ model: Media, as: 'media' }],
     });
+
+    return externalCv?.media ? externalCv : null;
   }
 
   /**

--- a/src/external-cvs/models/external-cv.model.ts
+++ b/src/external-cvs/models/external-cv.model.ts
@@ -1,0 +1,71 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  AllowNull,
+  BelongsTo,
+  Column,
+  CreatedAt,
+  DataType,
+  Default,
+  DeletedAt,
+  ForeignKey,
+  IsUUID,
+  Model,
+  PrimaryKey,
+  Table,
+  UpdatedAt,
+} from 'sequelize-typescript';
+import { Media } from 'src/medias/models';
+import { UserProfile } from 'src/user-profiles/models/user-profile.model';
+
+/**
+ * Links a candidate's `UserProfile` to the `Media` holding one uploaded CV file.
+ *
+ * Every upload creates a new row: previous rows are never overwritten, so a
+ * profile's CV history is the full set of its rows. The *current* CV is simply
+ * the most recently created row with `deletedAt = null` — there is no explicit
+ * "current" pointer.
+ *
+ * Soft-delete invariant (see also `Media.deletedAt`):
+ * - `ExternalCv.deletedAt` means "this link is no longer active". It is set
+ *   either when the candidate removes their CV (S3 and `Media` untouched), or
+ *   in cascade when the referenced `Media` is actually deleted from S3.
+ * - `Media.deletedAt` set ⇒ every referencing `ExternalCv.deletedAt` must be
+ *   set. The reverse does NOT hold.
+ */
+@Table({ tableName: 'ExternalCvs' })
+export class ExternalCv extends Model {
+  @IsUUID(4)
+  @PrimaryKey
+  @Default(DataType.UUIDV4)
+  @Column
+  id: string;
+
+  @ApiProperty()
+  @IsUUID(4)
+  @ForeignKey(() => UserProfile)
+  @AllowNull(false)
+  @Column
+  userProfileId: string;
+
+  @ApiProperty()
+  @IsUUID(4)
+  @ForeignKey(() => Media)
+  @AllowNull(false)
+  @Column
+  mediaId: string;
+
+  @CreatedAt
+  createdAt: Date;
+
+  @UpdatedAt
+  updatedAt: Date;
+
+  @DeletedAt
+  deletedAt: Date;
+
+  @BelongsTo(() => Media, 'mediaId')
+  media: Media;
+
+  @BelongsTo(() => UserProfile, 'userProfileId')
+  userProfile: UserProfile;
+}

--- a/src/external-cvs/models/index.ts
+++ b/src/external-cvs/models/index.ts
@@ -1,0 +1,2 @@
+export { ExtractedCVData } from './extracted-cv-data.model';
+export { ExternalCv } from './external-cv.model';

--- a/src/medias/medias.service.ts
+++ b/src/medias/medias.service.ts
@@ -40,6 +40,29 @@ export class MediasService {
     return this.mediaModel.bulkCreate(uploadedFilesData);
   }
 
+  /**
+   * Fills the `signedUrl` virtual field of the given medias, in place.
+   *
+   * Must be called by every path that serves medias to the client — and only
+   * by those: signing is useless for internal reads, and doing it here rather
+   * than in a model hook keeps `S3Service` injected, hence stubbable in tests.
+   *
+   * @param medias The medias to sign
+   * @returns The same medias, with `signedUrl` set
+   */
+  async attachSignedUrls<T extends Media>(medias: T[]): Promise<T[]> {
+    await Promise.all(
+      medias.map(async (media) => {
+        media.signedUrl = await this.s3Service.getSignedUrl(
+          media.s3Key,
+          media.mimeType,
+          'inline' // Permit to display the file directly in the browser
+        );
+      })
+    );
+    return medias;
+  }
+
   async findMediasByConversationId(
     conversationId: string,
     transaction?: Transaction
@@ -48,7 +71,7 @@ export class MediasService {
     // So we need to find all messages linked to the conversation
     // And then find all medias linked to the messages but without the assiociations
     // This is because we only need the medias and not the messages
-    return this.mediaModel.findAll({
+    const medias = await this.mediaModel.findAll({
       attributes: mediaAttributes,
       include: [
         {
@@ -71,10 +94,12 @@ export class MediasService {
       ],
       transaction,
     });
+
+    return this.attachSignedUrls(medias);
   }
 
   async findMediaByMessageId(messageId: string, transaction?: Transaction) {
-    return this.mediaModel.findAll({
+    const medias = await this.mediaModel.findAll({
       attributes: mediaAttributes,
       include: [
         {
@@ -88,6 +113,8 @@ export class MediasService {
       ],
       transaction,
     });
+
+    return this.attachSignedUrls(medias);
   }
 
   //////////////////////

--- a/src/medias/models/media.model.ts
+++ b/src/medias/models/media.model.ts
@@ -8,6 +8,7 @@ import {
   CreatedAt,
   DataType,
   Default,
+  DeletedAt,
   ForeignKey,
   IsUUID,
   Model,
@@ -32,6 +33,14 @@ export class Media extends Model {
 
   @UpdatedAt
   updatedAt: Date;
+
+  /**
+   * Set if and only if the underlying S3 object has actually been deleted.
+   * It must never be set to merely "unlink" a media from the feature that
+   * references it (see `ExternalCv.deletedAt` for that meaning).
+   */
+  @DeletedAt
+  deletedAt: Date;
 
   @ApiProperty()
   @IsString()

--- a/src/medias/models/media.model.ts
+++ b/src/medias/models/media.model.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString, MaxLength, MinLength } from 'class-validator';
 import {
-  AfterFind,
   AllowNull,
   BelongsToMany,
   Column,
@@ -16,7 +15,6 @@ import {
   Table,
   UpdatedAt,
 } from 'sequelize-typescript';
-import { S3Service } from 'src/external-services/aws/s3.service';
 import { Message, MessageMedia } from 'src/messaging/models';
 import { User } from 'src/users/models';
 
@@ -77,23 +75,14 @@ export class Media extends Model {
   @BelongsToMany(() => Message, () => MessageMedia)
   message?: Message;
 
+  /**
+   * Short-lived URL letting the client fetch the S3 object directly.
+   *
+   * Deliberately not filled by a model hook: it is only meaningful for medias
+   * served to the client, and signing on every read would both waste work on
+   * internal reads and bypass dependency injection. Callers that expose medias
+   * fill it through `MediasService.attachSignedUrls`.
+   */
   @Column(DataType.VIRTUAL)
   signedUrl!: string;
-
-  @AfterFind
-  static async generateSignedUrl(media: Media | Media[]) {
-    if (!Array.isArray(media)) {
-      media = [media];
-    }
-
-    const s3Service = new S3Service();
-
-    for (const item of media) {
-      item.signedUrl = await s3Service.getSignedUrl(
-        item.s3Key,
-        item.mimeType,
-        'inline' // Permit to display the file directly in the browser
-      );
-    }
-  }
 }

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -287,6 +287,15 @@ export class MessagingService {
         ],
       });
 
+    // Medias come straight from the includes here, so they still need their
+    // signed URL before being serialized to the client
+    await this.mediaService.attachSignedUrls(
+      conversationParticipants.flatMap(
+        ({ conversation }) =>
+          conversation?.messages?.flatMap(({ medias }) => medias ?? []) ?? []
+      )
+    );
+
     return conversationParticipants
       .filter((cp) => cp.conversation)
       .map((cp) => {

--- a/src/profile-generation/profile-generation.controller.ts
+++ b/src/profile-generation/profile-generation.controller.ts
@@ -12,6 +12,7 @@ import {
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import axios from 'axios';
 import { JwtAuthGuard, UserPayload } from 'src/auth/guards';
+import { ExternalCvsService } from 'src/external-cvs/external-cvs.service';
 import { ProfileGenerationService } from 'src/profile-generation/profile-generation.service';
 import { UserProfilesService } from 'src/user-profiles/user-profiles.service';
 
@@ -21,7 +22,8 @@ import { UserProfilesService } from 'src/user-profiles/user-profiles.service';
 export class ProfileGenerationController {
   constructor(
     private readonly profileGenerationService: ProfileGenerationService,
-    private readonly userProfilesService: UserProfilesService
+    private readonly userProfilesService: UserProfilesService,
+    private readonly externalCvsService: ExternalCvsService
   ) {}
 
   @ApiBearerAuth()
@@ -34,12 +36,19 @@ export class ProfileGenerationController {
       const userProfile =
         await this.userProfilesService.findOneByUserId(userId);
 
-      if (!userProfile || !userProfile.hasExternalCv) {
+      if (!userProfile) {
         throw new NotFoundException();
       }
 
-      // Construction de la clé S3 pour le CV externe
-      const pdfUrl = `https://${process.env.AWSS3_BUCKET_NAME}.s3.eu-west-3.amazonaws.com/${process.env.AWSS3_FILE_DIRECTORY}external-cvs/${userId}.pdf`;
+      const externalCv = await this.externalCvsService.findCurrentExternalCv(
+        userProfile.id
+      );
+      if (!externalCv) {
+        throw new NotFoundException();
+      }
+
+      const s3Key = externalCv.media.s3Key;
+      const pdfUrl = `https://${process.env.AWSS3_BUCKET_NAME}.s3.eu-west-3.amazonaws.com/${s3Key}`;
       const response = await axios.get(pdfUrl, { responseType: 'arraybuffer' });
       if (response.status !== 200) {
         throw new InternalServerErrorException(
@@ -63,7 +72,7 @@ export class ProfileGenerationController {
         try {
           // Création d'un job de génération de profil à partir du PDF
           return this.profileGenerationService.generateProfileFromPDF({
-            s3Key: `external-cvs/${userId}.pdf`,
+            s3Key,
             userProfileId: userProfile.id,
             userId,
             fileHash,

--- a/src/profile-generation/profile-generation.module.ts
+++ b/src/profile-generation/profile-generation.module.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
+import { ExternalCvsModule } from 'src/external-cvs/external-cvs.module';
 import { ExtractedCVData } from 'src/external-cvs/models/extracted-cv-data.model';
 import { LanguagesModule } from 'src/languages/languages.module';
 import { ProfileGenerationService } from 'src/profile-generation/profile-generation.service';
@@ -12,6 +13,7 @@ import { ProfileGenerationController } from './profile-generation.controller';
     SequelizeModule.forFeature([ExtractedCVData]),
     forwardRef(() => QueuesModule),
     forwardRef(() => UserProfilesModule),
+    forwardRef(() => ExternalCvsModule),
     LanguagesModule,
   ],
   controllers: [ProfileGenerationController],

--- a/src/queues/consumers/profile-generator.processor.ts
+++ b/src/queues/consumers/profile-generator.processor.ts
@@ -69,8 +69,8 @@ export class ProfileGeneratorProcessor extends WorkerHost {
     try {
       await job.updateProgress(10);
 
-      // Construire l'URL S3
-      const pdfUrl = `https://${process.env.AWSS3_BUCKET_NAME}.s3.eu-west-3.amazonaws.com/${process.env.AWSS3_FILE_DIRECTORY}${s3Key}`;
+      // Construire l'URL S3 — `s3Key` est la clé complète stockée en base
+      const pdfUrl = `https://${process.env.AWSS3_BUCKET_NAME}.s3.eu-west-3.amazonaws.com/${s3Key}`;
 
       // Télécharger le PDF depuis S3 directement dans le worker
       const tempDir = process.platform === 'darwin' ? '/tmp' : os.tmpdir();

--- a/src/queues/consumers/profile-generator.processor.ts
+++ b/src/queues/consumers/profile-generator.processor.ts
@@ -69,7 +69,7 @@ export class ProfileGeneratorProcessor extends WorkerHost {
     try {
       await job.updateProgress(10);
 
-      // Construire l'URL S3 — `s3Key` est la clé complète stockée en base
+      // Build the S3 URL — `s3Key` is the full key stored in database
       const pdfUrl = `https://${process.env.AWSS3_BUCKET_NAME}.s3.eu-west-3.amazonaws.com/${s3Key}`;
 
       // Télécharger le PDF depuis S3 directement dans le worker

--- a/src/scripts/migrate-external-cvs.ts
+++ b/src/scripts/migrate-external-cvs.ts
@@ -43,7 +43,7 @@ async function migrateExternalCvs() {
 
     const userProfiles = await userProfileModel.findAll({
       where: { hasExternalCv: true },
-      attributes: ['id', 'userId', 'deletedAt'],
+      attributes: ['id', 'userId'],
     });
 
     let migrated = 0;
@@ -87,7 +87,6 @@ async function migrateExternalCvs() {
       await externalCvModel.create({
         userProfileId: userProfile.id,
         mediaId: media.id,
-        deletedAt: userProfile.deletedAt,
       });
 
       migrated += 1;

--- a/src/scripts/migrate-external-cvs.ts
+++ b/src/scripts/migrate-external-cvs.ts
@@ -1,0 +1,109 @@
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { getModelToken } from '@nestjs/sequelize';
+import { AppModule } from 'src/app.module';
+import { ExternalCv } from 'src/external-cvs/models/external-cv.model';
+import { S3Service } from 'src/external-services/aws/s3.service';
+import { Media } from 'src/medias/models';
+import { UserProfile } from 'src/user-profiles/models';
+
+/**
+ * One-off backfill: registers the CV files that pre-date the `Media` /
+ * `ExternalCv` model.
+ *
+ * Before this change a CV was only tracked by `UserProfile.hasExternalCv`, the
+ * file living at a key that was never stored but rebuilt on the fly. This
+ * script resolves that key for every flagged profile, checks the object really
+ * exists in S3, and registers it as-is — no object is copied, moved, renamed
+ * or written.
+ *
+ * Run it (built app) with:
+ *   node dist/scripts/migrate-external-cvs
+ */
+
+/** The exact key the legacy upload path wrote to. */
+const buildLegacyS3Key = (userId: string) =>
+  `${process.env.AWSS3_FILE_DIRECTORY}external-cvs/${userId}.pdf`;
+
+async function migrateExternalCvs() {
+  const logger = new Logger('MigrateExternalCvs');
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn', 'log'],
+  });
+
+  try {
+    const s3Service = app.get(S3Service);
+    const userProfileModel = app.get<typeof UserProfile>(
+      getModelToken(UserProfile)
+    );
+    const mediaModel = app.get<typeof Media>(getModelToken(Media));
+    const externalCvModel = app.get<typeof ExternalCv>(
+      getModelToken(ExternalCv)
+    );
+
+    const userProfiles = await userProfileModel.findAll({
+      where: { hasExternalCv: true },
+      attributes: ['id', 'userId', 'deletedAt'],
+    });
+
+    let migrated = 0;
+    let skipped = 0;
+    let alreadyMigrated = 0;
+
+    for (const userProfile of userProfiles) {
+      // Idempotent: a profile already linked to a CV is left untouched, so the
+      // script can safely be re-run after a partial run.
+      const existingExternalCv = await externalCvModel.findOne({
+        where: { userProfileId: userProfile.id },
+        paranoid: false,
+      });
+      if (existingExternalCv) {
+        alreadyMigrated += 1;
+        continue;
+      }
+
+      const s3Key = buildLegacyS3Key(userProfile.userId);
+
+      let contentLength: number;
+      try {
+        const head = await s3Service.getHead(s3Key);
+        contentLength = head?.ContentLength ?? 0;
+      } catch {
+        skipped += 1;
+        logger.warn(
+          `Skipped profile ${userProfile.id} (user ${userProfile.userId}): no S3 object at ${s3Key}`
+        );
+        continue;
+      }
+
+      const media = await mediaModel.create({
+        name: 'cv.pdf',
+        s3Key,
+        mimeType: 'application/pdf',
+        size: contentLength,
+        userId: userProfile.userId,
+      });
+
+      await externalCvModel.create({
+        userProfileId: userProfile.id,
+        mediaId: media.id,
+        deletedAt: userProfile.deletedAt,
+      });
+
+      migrated += 1;
+    }
+
+    logger.log(
+      `Done — processed: ${userProfiles.length}, migrated: ${migrated}, already migrated: ${alreadyMigrated}, skipped (missing S3 object): ${skipped}`
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+migrateExternalCvs()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('External CVs migration failed:', error);
+    process.exit(1);
+  });

--- a/src/user-profiles/dto/public-profile.dto.ts
+++ b/src/user-profiles/dto/public-profile.dto.ts
@@ -14,6 +14,7 @@ import { Skill } from 'src/skills/models';
 import { User } from 'src/users/models';
 import { Gender, UserRole } from 'src/users/users.types';
 import { ZoneName } from 'src/utils/types/zones.types';
+import { hasCurrentExternalCv } from './user-profile.dto';
 
 export type PublicProfileDto = {
   achievements: UserAchievement[];
@@ -82,7 +83,7 @@ export const generatePublicProfileDto = (
     reviews: userProfile.reviews,
     interests: userProfile.interests,
     linkedinUrl: userProfile.linkedinUrl,
-    hasExternalCv: userProfile.hasExternalCv,
+    hasExternalCv: hasCurrentExternalCv(userProfile),
     hasPicture: userProfile.hasPicture,
     company: null,
     zone: user.zone,

--- a/src/user-profiles/dto/user-profile.dto.ts
+++ b/src/user-profiles/dto/user-profile.dto.ts
@@ -2,6 +2,16 @@ import { UserProfile, UserProfileWithPartialAssociations } from '../models';
 
 export type UserProfileDto = UserProfileWithPartialAssociations;
 
+/**
+ * `hasExternalCv` is not a stored column anymore: it is derived from the
+ * presence of at least one still-active `ExternalCv` link on the profile.
+ *
+ * Requires the `externalCvs` association to have been included in the query
+ * (see `getUserProfileInclude`).
+ */
+export const hasCurrentExternalCv = (userProfile: UserProfile): boolean =>
+  (userProfile?.externalCvs?.length ?? 0) > 0;
+
 export const generateUserProfileDto = (
   userProfile: UserProfile | null,
   complete = false
@@ -17,7 +27,7 @@ export const generateUserProfileDto = (
     nudges: userProfile.nudges,
     description: userProfile.description,
     linkedinUrl: userProfile.linkedinUrl,
-    hasExternalCv: userProfile.hasExternalCv,
+    hasExternalCv: hasCurrentExternalCv(userProfile),
     sectorOccupations: userProfile.sectorOccupations,
     hasPicture: userProfile.hasPicture,
     optInRecommendations: userProfile.optInRecommendations,

--- a/src/user-profiles/models/user-profile.attributes.ts
+++ b/src/user-profiles/models/user-profile.attributes.ts
@@ -9,7 +9,6 @@ export const UserProfilesAttributes = [
   'linkedinUrl',
   'optInNewsletter',
   'optInRecommendations',
-  'hasExternalCv',
   'hasPicture',
 ];
 

--- a/src/user-profiles/models/user-profile.include.ts
+++ b/src/user-profiles/models/user-profile.include.ts
@@ -1,5 +1,6 @@
 import { Includeable, Order, WhereOptions } from 'sequelize';
 import { BusinessSector } from 'src/business-sectors/models';
+import { ExternalCv } from 'src/external-cvs/models/external-cv.model';
 import { Nudge } from 'src/nudge/models';
 import { getUserProfileNudgesInclude } from 'src/user-profile-nudges/user-profile-nudges.include';
 import { getUserProfileSectorOccupationsInclude } from 'src/user-profile-sector-occupations/user-profile-sector-occupations.include';
@@ -18,6 +19,19 @@ export const getUserProfileInclude = (
       withAttributes
     ),
     ...getUserProfileNudgesInclude(nudgesOptions, withAttributes),
+    // Only the ids are needed: the DTOs derive `hasExternalCv` from the
+    // presence of at least one active link. Skipped when attributes are not
+    // requested, because those queries only filter/group on profile ids.
+    ...(withAttributes
+      ? [
+          {
+            model: ExternalCv,
+            as: 'externalCvs',
+            attributes: ['id'],
+            required: false,
+          },
+        ]
+      : []),
   ];
 };
 

--- a/src/user-profiles/models/user-profile.model.ts
+++ b/src/user-profiles/models/user-profile.model.ts
@@ -32,6 +32,7 @@ import { BusinessSector } from 'src/business-sectors/models';
 import { Review } from 'src/common/reviews/models';
 import { Contract } from 'src/contracts/models';
 import { Experience } from 'src/experiences/models';
+import { ExternalCv } from 'src/external-cvs/models/external-cv.model';
 import { Formation } from 'src/formations/models';
 import { Interest } from 'src/interests/models';
 import { Language } from 'src/languages/models';
@@ -315,6 +316,13 @@ export class UserProfile extends Model {
   @IsOptional()
   @HasMany(() => UserProfileEmbedding, 'userProfileId')
   embeddings: UserProfileEmbedding[];
+
+  // External CVs — `ExternalCv` is paranoid, so this only ever exposes the
+  // still-active links. Used to derive `hasExternalCv` in the DTOs.
+  @IsArray()
+  @IsOptional()
+  @HasMany(() => ExternalCv, 'userProfileId')
+  externalCvs: ExternalCv[];
 
   /**
    * Hooks

--- a/src/user-profiles/user-profiles.module.ts
+++ b/src/user-profiles/user-profiles.module.ts
@@ -3,8 +3,10 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { ReviewsModule } from 'src/common/reviews/reviews.module';
 import { CompanyUser } from 'src/companies/models/company-user.model';
 import { DepartmentsModule } from 'src/departments/departments.module';
+import { ExternalCv } from 'src/external-cvs/models/external-cv.model';
 import { SlackModule } from 'src/external-services/slack/slack.module';
 import { MailsModule } from 'src/mails/mails.module';
+import { Media } from 'src/medias/models';
 import { QueuesModule } from 'src/queues/producers';
 import { UserProfileAnalyticsModule } from 'src/user-profile-analytics/user-profile-analytics.module';
 import { UserProfileContractsModule } from 'src/user-profile-contracts/user-profile-contracts.module';
@@ -32,6 +34,11 @@ import { UserProfilesService } from './user-profiles.service';
       UserProfile,
       UserProfileSectorOccupation,
       CompanyUser,
+      // Registered here (and not only in ExternalCvsModule) so that the
+      // `UserProfile.externalCvs` association always resolves, including in
+      // contexts that load UserProfilesModule without ExternalCvsModule.
+      ExternalCv,
+      Media,
     ]),
     forwardRef(() => UsersModule),
     SlackModule,

--- a/src/user-profiles/user-profiles.service.ts
+++ b/src/user-profiles/user-profiles.service.ts
@@ -66,6 +66,7 @@ import {
   availabilityWhere,
   profileVisibilityEligibilityWhere,
   userProfileSearchQuery,
+  withHasExternalCv,
 } from './user-profiles.utils';
 
 const LINKEDIN_ENTOURAGE_PRO_ORG_ID = '42693016';
@@ -331,7 +332,9 @@ export class UserProfilesService {
             profile.user.id
           );
 
-        const { user, ...restProfile }: UserProfile = profile.toJSON();
+        const { user, ...restProfile } = withHasExternalCv(
+          profile.toJSON<UserProfile>()
+        );
         return {
           ...user,
           ...restProfile,
@@ -540,7 +543,9 @@ export class UserProfilesService {
           await this.userProfileAnalyticsService.getAverageDelayResponse(
             profile.user.id
           );
-        const { user, ...restProfile }: UserProfile = profile.toJSON();
+        const { user, ...restProfile } = withHasExternalCv(
+          profile.toJSON<UserProfile>()
+        );
         return {
           ...user,
           ...restProfile,
@@ -737,7 +742,7 @@ export class UserProfilesService {
           await this.userProfileAnalyticsService.getAverageDelayResponse(
             profile.user.id
           );
-        const { user, ...restProfile } = profile.toJSON();
+        const { user, ...restProfile } = withHasExternalCv(profile.toJSON());
         return {
           ...user,
           ...restProfile,

--- a/src/user-profiles/user-profiles.utils.ts
+++ b/src/user-profiles/user-profiles.utils.ts
@@ -46,6 +46,19 @@ export function isProfileVisibilityEligible(
 }
 
 /**
+ * Normalizes a serialized profile whose `externalCvs` links were included only
+ * to derive CV presence: the links are dropped and replaced by the public
+ * `hasExternalCv` boolean, so the payload shape stays unchanged now that
+ * `hasExternalCv` is no longer a stored column.
+ */
+export function withHasExternalCv<T extends { externalCvs?: { id: string }[] }>(
+  profile: T
+): Omit<T, 'externalCvs'> & { hasExternalCv: boolean } {
+  const { externalCvs, ...rest } = profile;
+  return { ...rest, hasExternalCv: (externalCvs?.length ?? 0) > 0 };
+}
+
+/**
  * Translates the public "isAvailable" filter (still expressed as a boolean at
  * the API boundary) into a `WhereOptions` targeting `unavailableAt`, the
  * actual source of truth: `NULL` = available, a date = unavailable since then.

--- a/src/users-deletion/users-deletion.module.ts
+++ b/src/users-deletion/users-deletion.module.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { ExternalCvsModule } from 'src/external-cvs/external-cvs.module';
 import { AWSModule } from 'src/external-services/aws/aws.module';
 import { MailsModule } from 'src/mails/mails.module';
 import { UserProfileDeletionModule } from 'src/user-profile-deletion/user-profile-deletion.module';
@@ -10,6 +11,7 @@ import { UsersDeletionService } from './users-deletion.service';
   imports: [
     UserProfileDeletionModule,
     forwardRef(() => UsersModule),
+    forwardRef(() => ExternalCvsModule),
     AWSModule,
     MailsModule,
   ],

--- a/src/users-deletion/users-deletion.service.ts
+++ b/src/users-deletion/users-deletion.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { v4 as uuid } from 'uuid';
+import { ExternalCvsService } from 'src/external-cvs/external-cvs.service';
 import { S3Service } from 'src/external-services/aws/s3.service';
 import { UserProfileDeletionService } from 'src/user-profile-deletion/user-profile-deletion.service';
 import { UpdateUserDto } from 'src/users/dto';
@@ -11,7 +12,9 @@ export class UsersDeletionService {
   constructor(
     private usersService: UsersService,
     private userProfileDeletionService: UserProfileDeletionService,
-    private s3Service: S3Service
+    private s3Service: S3Service,
+    @Inject(forwardRef(() => ExternalCvsService))
+    private externalCvsService: ExternalCvsService
   ) {}
 
   async findOneUser(userId: string) {
@@ -42,6 +45,9 @@ export class UsersDeletionService {
   ): Promise<{ userDeleted: number }> {
     const { id, firstName, lastName } = user;
     await this.removeFiles(id, firstName, lastName);
+    // Must run before `removeUserProfile`: the profile row is needed to
+    // resolve the user's CV media.
+    await this.externalCvsService.deleteAllExternalCvsForUser(id);
     await this.updateUser(id, {
       firstName: 'Utilisateur',
       lastName: 'supprimé',

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -21,6 +21,7 @@ import { validate as uuidValidate } from 'uuid';
 import validator from 'validator';
 import { encryptPassword, validatePassword } from 'src/auth/auth.utils';
 import { UserPayload } from 'src/auth/guards';
+import { withHasExternalCv } from 'src/user-profiles/user-profiles.utils';
 import {
   UpdateUserDto,
   UpdateUserRestrictedDto,
@@ -138,7 +139,11 @@ export class UsersController {
       throw new NotFoundException();
     }
 
-    return user.toJSON();
+    const { userProfile, ...restUser } = user.toJSON() as User;
+    return {
+      ...restUser,
+      ...(userProfile ? { userProfile: withHasExternalCv(userProfile) } : {}),
+    };
   }
 
   @Put('changePwd')

--- a/tests/database.helper.ts
+++ b/tests/database.helper.ts
@@ -11,7 +11,9 @@ import { ElearningQuestion } from 'src/elearning/models/elearning-question.model
 import { ElearningUnitRole } from 'src/elearning/models/elearning-unit-role.model';
 import { ElearningUnit } from 'src/elearning/models/elearning-unit.model';
 import { Experience, ExperienceSkill } from 'src/experiences/models';
+import { ExternalCv } from 'src/external-cvs/models/external-cv.model';
 import { Formation, FormationSkill } from 'src/formations/models';
+import { Media } from 'src/medias/models';
 import {
   Conversation,
   ConversationParticipant,
@@ -89,7 +91,11 @@ export class DatabaseHelper {
     @InjectModel(ElearningUnitRole)
     private elearningUnitRoleModel: typeof ElearningUnitRole,
     @InjectModel(ElearningUnit)
-    private elearningUnitModel: typeof ElearningUnit
+    private elearningUnitModel: typeof ElearningUnit,
+    @InjectModel(ExternalCv)
+    private externalCvModel: typeof ExternalCv,
+    @InjectModel(Media)
+    private mediaModel: typeof Media
   ) {}
 
   async resetTestDB() {
@@ -121,6 +127,8 @@ export class DatabaseHelper {
       await this.organizationModel.truncate(destroyOptions);
       await this.organizationReferentModel.truncate(destroyOptions);
       await this.userSocialSituationModel.truncate(destroyOptions);
+      await this.externalCvModel.truncate(destroyOptions);
+      await this.mediaModel.truncate(destroyOptions);
       await this.userProfileModel.truncate(destroyOptions);
       await this.userModel.truncate(destroyOptions);
       await this.userProfileNudge.truncate(destroyOptions);

--- a/tests/external-cvs/external-cvs-testing.module.ts
+++ b/tests/external-cvs/external-cvs-testing.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
+import { SequelizeModule } from '@nestjs/sequelize';
+import { ExternalCv } from 'src/external-cvs/models/external-cv.model';
+import { Media } from 'src/medias/models';
 import { UsersModule } from 'src/users/users.module';
+import { ExternalCvsHelper } from './external-cvs.helper';
 
 @Module({
-  imports: [UsersModule],
-  providers: [],
-  exports: [],
+  imports: [UsersModule, SequelizeModule.forFeature([ExternalCv, Media])],
+  providers: [ExternalCvsHelper],
+  exports: [ExternalCvsHelper],
 })
 export class ExternalCvsTestingModule {}

--- a/tests/external-cvs/external-cvs.e2e-spec.ts
+++ b/tests/external-cvs/external-cvs.e2e-spec.ts
@@ -1,17 +1,18 @@
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
-import { UserProfilesHelper } from '../user-profiles/user-profiles.helper';
 import { UsersHelper, LoggedInUser } from '../users/users.helper';
 import { ExternalCvsController } from 'src/external-cvs/external-cvs.controller';
 import { S3Service } from 'src/external-services/aws/s3.service';
 import { QueuesService } from 'src/queues/producers/queues.service';
 import { UserRoles } from 'src/users/users.types';
+import { UsersDeletionController } from 'src/users-deletion/users-deletion.controller';
 import { APIResponse } from 'src/utils/types';
 import { CustomTestingModule } from 'tests/custom-testing.module';
 import { DatabaseHelper } from 'tests/database.helper';
 import { S3Mocks } from 'tests/mocks.types';
 import { QueuesServiceMock } from 'tests/queues/queues.service.mock';
+import { ExternalCvsHelper } from './external-cvs.helper';
 
 describe('ExternalCvs', () => {
   let app: INestApplication;
@@ -20,9 +21,10 @@ describe('ExternalCvs', () => {
 
   let databaseHelper: DatabaseHelper;
   let usersHelper: UsersHelper;
-  let userProfilesHelper: UserProfilesHelper;
+  let externalCvsHelper: ExternalCvsHelper;
   let loggedInCandidate: LoggedInUser;
   let loggedInCandidateWithCv: LoggedInUser;
+  let candidateWithCvProfileId: string;
 
   const route = '/external-cv';
 
@@ -42,8 +44,7 @@ describe('ExternalCvs', () => {
 
     databaseHelper = moduleFixture.get<DatabaseHelper>(DatabaseHelper);
     usersHelper = moduleFixture.get<UsersHelper>(UsersHelper);
-    userProfilesHelper =
-      moduleFixture.get<UserProfilesHelper>(UserProfilesHelper);
+    externalCvsHelper = moduleFixture.get<ExternalCvsHelper>(ExternalCvsHelper);
   });
 
   afterAll(async () => {
@@ -53,19 +54,22 @@ describe('ExternalCvs', () => {
   });
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     await databaseHelper.resetTestDB();
     loggedInCandidate = await usersHelper.createLoggedInUser({
       role: UserRoles.CANDIDATE,
     });
 
-    // Create a candidate with an external CV
-    loggedInCandidateWithCv = await usersHelper.createLoggedInUser(
-      { role: UserRoles.CANDIDATE },
-      {
-        userProfile: {
-          hasExternalCv: true,
-        },
-      }
+    // Create a candidate with an already uploaded external CV
+    loggedInCandidateWithCv = await usersHelper.createLoggedInUser({
+      role: UserRoles.CANDIDATE,
+    });
+    candidateWithCvProfileId = loggedInCandidateWithCv.user.userProfile.id;
+    await externalCvsHelper.createExternalCv(
+      candidateWithCvProfileId,
+      loggedInCandidateWithCv.user.id,
+      // Explicit dates keep the "most recent version" ordering deterministic
+      { createdAt: new Date('2026-01-01T00:00:00Z') }
     );
   });
 
@@ -81,6 +85,17 @@ describe('ExternalCvs', () => {
 
       expect(response.status).toBe(201);
       expect(response.body).toHaveProperty('url');
+
+      const externalCvs = await externalCvsHelper.findExternalCvs(
+        loggedInCandidate.user.userProfile.id
+      );
+      expect(externalCvs).toHaveLength(1);
+
+      const media = await externalCvsHelper.findMedia(externalCvs[0].mediaId);
+      expect(media.deletedAt).toBeFalsy();
+      expect(media.s3Key).toContain(
+        `external-cvs/${loggedInCandidate.user.id}`
+      );
     });
 
     it('should fail to upload an external CV if no file was provided', async () => {
@@ -90,6 +105,45 @@ describe('ExternalCvs', () => {
           .set('authorization', `Bearer ${loggedInCandidate.token}`);
 
       expect(response.status).toBe(400);
+    });
+
+    it('should keep the previous version untouched when uploading a new CV', async () => {
+      const [previousExternalCv] = await externalCvsHelper.findExternalCvs(
+        candidateWithCvProfileId
+      );
+
+      const buffer = Buffer.from('PDFFileContent');
+      const response: APIResponse<ExternalCvsController['uploadExternalCV']> =
+        await request(server)
+          .post(`${route}`)
+          .set('authorization', `Bearer ${loggedInCandidateWithCv.token}`)
+          .set('Content-Type', 'multipart/form-data')
+          .attach('file', buffer, 'test.pdf');
+
+      expect(response.status).toBe(201);
+
+      const externalCvs = await externalCvsHelper.findExternalCvs(
+        candidateWithCvProfileId
+      );
+      expect(externalCvs).toHaveLength(2);
+
+      // The previous link is still active and still points at its own media
+      const stillThere = externalCvs.find(
+        ({ id }) => id === previousExternalCv.id
+      );
+      expect(stillThere).toBeTruthy();
+      expect(stillThere.deletedAt).toBeFalsy();
+      expect(stillThere.mediaId).toBe(previousExternalCv.mediaId);
+
+      const previousMedia = await externalCvsHelper.findMedia(
+        previousExternalCv.mediaId
+      );
+      expect(previousMedia.deletedAt).toBeFalsy();
+
+      // Both versions are distinct S3 objects
+      const mediaIds = externalCvs.map(({ mediaId }) => mediaId);
+      expect(new Set(mediaIds).size).toBe(2);
+      expect(S3Mocks.deleteFiles).not.toHaveBeenCalled();
     });
   });
 
@@ -110,23 +164,185 @@ describe('ExternalCvs', () => {
           .set('authorization', `Bearer ${loggedInCandidate.token}`);
       expect(response.status).toBe(404);
     });
+
+    it('should resolve the most recent non-deleted version as the current CV', async () => {
+      const latest = await externalCvsHelper.createExternalCv(
+        candidateWithCvProfileId,
+        loggedInCandidateWithCv.user.id,
+        { createdAt: new Date('2026-06-01T00:00:00Z') }
+      );
+      const latestMedia = await externalCvsHelper.findMedia(latest.mediaId);
+
+      const response: APIResponse<ExternalCvsController['findExternalCv']> =
+        await request(server)
+          .get(`${route}/${loggedInCandidateWithCv.user.id}`)
+          .set('authorization', `Bearer ${loggedInCandidateWithCv.token}`);
+
+      expect(response.status).toBe(200);
+      expect(S3Mocks.getSignedUrl).toHaveBeenCalledWith(
+        latestMedia.s3Key,
+        'application/pdf',
+        expect.stringContaining('attachment')
+      );
+    });
+
+    it('should serve the file back under its original name', async () => {
+      await externalCvsHelper.createExternalCv(
+        candidateWithCvProfileId,
+        loggedInCandidateWithCv.user.id,
+        {
+          createdAt: new Date('2026-06-01T00:00:00Z'),
+          name: 'CV Élodie Dupont.pdf',
+        }
+      );
+
+      const response: APIResponse<ExternalCvsController['findExternalCv']> =
+        await request(server)
+          .get(`${route}/${loggedInCandidateWithCv.user.id}`)
+          .set('authorization', `Bearer ${loggedInCandidateWithCv.token}`);
+
+      expect(response.status).toBe(200);
+      // ASCII fallback + RFC 5987 form, so the accent survives
+      expect(S3Mocks.getSignedUrl).toHaveBeenCalledWith(
+        expect.any(String),
+        'application/pdf',
+        `attachment; filename="CV _lodie Dupont.pdf"; filename*=UTF-8''CV%20%C3%89lodie%20Dupont.pdf`
+      );
+    });
   });
 
   describe('deleteExternalCv', () => {
     it('should successfully delete an external CV', async () => {
-      // Delete the external CV
       const response: APIResponse<ExternalCvsController['deleteExternalCv']> =
         await request(server)
           .delete(`${route}`)
           .set('authorization', `Bearer ${loggedInCandidateWithCv.token}`);
 
-      // Compute the user profile
-      const profile = await userProfilesHelper.findOneProfileByUserId(
-        loggedInCandidateWithCv.user.id
+      expect(response.status).toBe(200);
+
+      const activeExternalCvs = await externalCvsHelper.findExternalCvs(
+        candidateWithCvProfileId
+      );
+      expect(activeExternalCvs).toHaveLength(0);
+
+      const profileResponse = await request(server)
+        .get('/current/profile')
+        .set('authorization', `Bearer ${loggedInCandidateWithCv.token}`);
+      expect(profileResponse.body.hasExternalCv).toBe(false);
+    });
+
+    it('should soft-delete every version and leave S3 and the medias untouched', async () => {
+      await externalCvsHelper.createExternalCv(
+        candidateWithCvProfileId,
+        loggedInCandidateWithCv.user.id,
+        { createdAt: new Date('2026-06-01T00:00:00Z') }
       );
 
+      const response: APIResponse<ExternalCvsController['deleteExternalCv']> =
+        await request(server)
+          .delete(`${route}`)
+          .set('authorization', `Bearer ${loggedInCandidateWithCv.token}`);
+
       expect(response.status).toBe(200);
-      expect(profile.hasExternalCv).toBe(false);
+
+      const allExternalCvs = await externalCvsHelper.findExternalCvs(
+        candidateWithCvProfileId,
+        { withDeleted: true }
+      );
+      expect(allExternalCvs).toHaveLength(2);
+      allExternalCvs.forEach((externalCv) => {
+        expect(externalCv.deletedAt).toBeTruthy();
+      });
+
+      for (const { mediaId } of allExternalCvs) {
+        const media = await externalCvsHelper.findMedia(mediaId);
+        expect(media.deletedAt).toBeFalsy();
+      }
+      expect(S3Mocks.deleteFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hasExternalCv in the profile DTO', () => {
+    it('should be true for a candidate with a current CV', async () => {
+      const response = await request(server)
+        .get('/current/profile')
+        .set('authorization', `Bearer ${loggedInCandidateWithCv.token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.hasExternalCv).toBe(true);
+    });
+
+    it('should be false for a candidate without any CV', async () => {
+      const response = await request(server)
+        .get('/current/profile')
+        .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.hasExternalCv).toBe(false);
+    });
+  });
+
+  describe('account deletion', () => {
+    it('should delete every CV file from S3 and soft-delete both sides', async () => {
+      const loggedInAdmin = await usersHelper.createLoggedInUser({
+        role: UserRoles.ADMIN,
+      });
+
+      // A removed CV whose file is still in S3, plus a current one
+      const removed = await externalCvsHelper.createExternalCv(
+        candidateWithCvProfileId,
+        loggedInCandidateWithCv.user.id,
+        { deletedAt: new Date() }
+      );
+      const [current] = await externalCvsHelper.findExternalCvs(
+        candidateWithCvProfileId
+      );
+      const removedMedia = await externalCvsHelper.findMedia(removed.mediaId);
+      const currentMedia = await externalCvsHelper.findMedia(current.mediaId);
+
+      const response: APIResponse<UsersDeletionController['removeUser']> =
+        await request(server)
+          .delete(`/user/${loggedInCandidateWithCv.user.id}`)
+          .set('authorization', `Bearer ${loggedInAdmin.token}`);
+
+      expect(response.status).toBe(200);
+
+      const deletedKeys = (S3Mocks.deleteFiles as jest.Mock).mock.calls.flat(2);
+      expect(deletedKeys).toEqual(
+        expect.arrayContaining([removedMedia.s3Key, currentMedia.s3Key])
+      );
+
+      for (const mediaId of [removed.mediaId, current.mediaId]) {
+        const media = await externalCvsHelper.findMedia(mediaId);
+        expect(media.deletedAt).toBeTruthy();
+      }
+
+      const allExternalCvs = await externalCvsHelper.findExternalCvs(
+        candidateWithCvProfileId,
+        { withDeleted: true }
+      );
+      expect(allExternalCvs).toHaveLength(2);
+      allExternalCvs.forEach((externalCv) => {
+        expect(externalCv.deletedAt).toBeTruthy();
+      });
+    });
+
+    it('should not call S3 for a user without any CV', async () => {
+      const loggedInAdmin = await usersHelper.createLoggedInUser({
+        role: UserRoles.ADMIN,
+      });
+
+      const response: APIResponse<UsersDeletionController['removeUser']> =
+        await request(server)
+          .delete(`/user/${loggedInCandidate.user.id}`)
+          .set('authorization', `Bearer ${loggedInAdmin.token}`);
+
+      expect(response.status).toBe(200);
+      // Only the legacy generated-CV cleanup, never a CV media batch delete
+      const deletedKeys = (S3Mocks.deleteFiles as jest.Mock).mock.calls.flat(2);
+      expect(
+        deletedKeys.filter((key: string) => key.includes('external-cvs/'))
+      ).toHaveLength(0);
     });
   });
 });

--- a/tests/external-cvs/external-cvs.e2e-spec.ts
+++ b/tests/external-cvs/external-cvs.e2e-spec.ts
@@ -186,6 +186,34 @@ describe('ExternalCvs', () => {
       );
     });
 
+    it('should report no current CV when the latest link lost its media, never falling back to an older version', async () => {
+      const [previous] = await externalCvsHelper.findExternalCvs(
+        candidateWithCvProfileId
+      );
+      const previousMedia = await externalCvsHelper.findMedia(previous.mediaId);
+
+      const latest = await externalCvsHelper.createExternalCv(
+        candidateWithCvProfileId,
+        loggedInCandidateWithCv.user.id,
+        { createdAt: new Date('2026-06-01T00:00:00Z') }
+      );
+      // Broken cascade: the file is gone but the link is still active
+      await externalCvsHelper.deleteMedia(latest.mediaId);
+
+      const response: APIResponse<ExternalCvsController['findExternalCv']> =
+        await request(server)
+          .get(`${route}/${loggedInCandidateWithCv.user.id}`)
+          .set('authorization', `Bearer ${loggedInCandidateWithCv.token}`);
+
+      expect(response.status).toBe(404);
+      // The still-live older version must not resurface
+      expect(S3Mocks.getSignedUrl).not.toHaveBeenCalledWith(
+        previousMedia.s3Key,
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
     it('should serve the file back under its original name', async () => {
       await externalCvsHelper.createExternalCv(
         candidateWithCvProfileId,

--- a/tests/external-cvs/external-cvs.helper.ts
+++ b/tests/external-cvs/external-cvs.helper.ts
@@ -53,4 +53,12 @@ export class ExternalCvsHelper {
   async findMedia(mediaId: string): Promise<Media | null> {
     return this.mediaModel.findByPk(mediaId, { paranoid: false });
   }
+
+  /**
+   * Soft-deletes a media without soft-deleting the links pointing at it, to
+   * reproduce a broken cascade (the state the `required` include guards).
+   */
+  async deleteMedia(mediaId: string): Promise<number> {
+    return this.mediaModel.destroy({ where: { id: mediaId } });
+  }
 }

--- a/tests/external-cvs/external-cvs.helper.ts
+++ b/tests/external-cvs/external-cvs.helper.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/sequelize';
+import { v4 as uuid } from 'uuid';
+import { ExternalCv } from 'src/external-cvs/models/external-cv.model';
+import { Media } from 'src/medias/models';
+
+@Injectable()
+export class ExternalCvsHelper {
+  constructor(
+    @InjectModel(ExternalCv)
+    private externalCvModel: typeof ExternalCv,
+    @InjectModel(Media)
+    private mediaModel: typeof Media
+  ) {}
+
+  /**
+   * Creates a CV version (a `Media` and the `ExternalCv` linking it to the
+   * profile) without going through S3.
+   */
+  async createExternalCv(
+    userProfileId: string,
+    userId: string,
+    props: { createdAt?: Date; deletedAt?: Date; name?: string } = {}
+  ): Promise<ExternalCv> {
+    const { name = 'cv.pdf', ...externalCvProps } = props;
+
+    const media = await this.mediaModel.create({
+      name,
+      s3Key: `files/external-cvs/${userId}_${uuid()}.pdf`,
+      mimeType: 'application/pdf',
+      size: 1234,
+      userId,
+    });
+
+    return this.externalCvModel.create({
+      userProfileId,
+      mediaId: media.id,
+      ...externalCvProps,
+    });
+  }
+
+  async findExternalCvs(
+    userProfileId: string,
+    { withDeleted = false } = {}
+  ): Promise<ExternalCv[]> {
+    return this.externalCvModel.findAll({
+      where: { userProfileId },
+      order: [['createdAt', 'ASC']],
+      paranoid: !withDeleted,
+    });
+  }
+
+  async findMedia(mediaId: string): Promise<Media | null> {
+    return this.mediaModel.findByPk(mediaId, { paranoid: false });
+  }
+}

--- a/tests/mocks.types.ts
+++ b/tests/mocks.types.ts
@@ -1,6 +1,6 @@
 import { Queue } from 'bullmq';
 import { CloudFrontService } from 'src/external-services/aws/cloud-front.service';
-import { S3Service } from 'src/external-services/aws/s3.service';
+import { S3File, S3Service } from 'src/external-services/aws/s3.service';
 import { MailjetService } from 'src/external-services/mailjet/mailjet.service';
 import { SalesforceService } from 'src/external-services/salesforce/salesforce.service';
 import { SlackService } from 'src/external-services/slack/slack.service';
@@ -15,9 +15,18 @@ export const QueueMocks: Partial<ProviderMock<Queue>> & {
 } as const;
 
 export const S3Mocks: ProviderMock<S3Service> = {
-  upload: jest.fn(async () => {
-    return 'key';
-  }),
+  // Mirrors the real service: the returned key is the requested path prefixed
+  // by the S3 directory, so callers storing it (e.g. `Media.s3Key`) get a
+  // distinct key per upload.
+  upload: jest.fn(
+    async (
+      _data: unknown,
+      _contentType: string,
+      outputPath: string
+    ): Promise<S3File> => {
+      return { key: `files/${outputPath}`, publicUrl: null };
+    }
+  ),
   copyFile: jest.fn(async () => {
     return {};
   }),


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9459](https://entourage-asso.atlassian.net/browse/EN-9459)
**💬 Commentaire :**

This pull request introduces a new versioned and auditable model for handling external CV uploads, replacing the previous single-file-per-user approach. It adds a normalized `ExternalCv` model that links `UserProfile` and `Media`, supports soft-deletion, and ensures that all historical uploads are preserved. The changes also update the upload, download, and deletion flows to use the new model, and refactor related services and controllers for improved reliability and future extensibility.

**Database and Model Changes:**

* Added a new `ExternalCv` model and migration, linking each CV upload to a user profile and media file, with support for soft-deletion via a `deletedAt` column. [[1]](diffhunk://#diff-009c9ccdd618f68f654e83157a54567cc39e9b82d1b70d4860a009846c1cd741R1-R43) [[2]](diffhunk://#diff-7ee0da28d8e48e5bfee7cd98301a3f2513e64ee8fc20df5187af96c46fcda961R1-R71)
* Added a `deletedAt` column to the `Medias` table and model to track when an S3 object has been deleted, enabling proper cleanup and invariants. [[1]](diffhunk://#diff-0b0f93bcccffa4f344688b313039c74c36ae8ee9c7998762b1bf3645e68f1440R1-R17) [[2]](diffhunk://#diff-c6159357ea0a4a605c344a47650a02f5b00cd61c20619279ad6ce20b95cf4d58R37-R44)

**Service and Controller Refactors:**

* Refactored `ExternalCvsService` to:
  * Upload each CV as a new S3 object and `Media`/`ExternalCv` pair, never overwriting or deleting previous versions.
  * Provide methods to find the current CV, generate signed download URLs with the original filename, and handle both soft and hard deletion of CVs and their media. [[1]](diffhunk://#diff-9989cca806737fc743beae94039571edf2accf62e8a02255054f1eda68a18eceL60-R169) [[2]](diffhunk://#diff-9989cca806737fc743beae94039571edf2accf62e8a02255054f1eda68a18eceL81-R249)
* Updated `ExternalCvsController` to use the new service methods for upload and download, returning signed URLs and ensuring robust error handling. [[1]](diffhunk://#diff-2729e097eff5b2564b8ab302eed00049c9945c60d14326a6c549b01308b1b1aaL47-R53) [[2]](diffhunk://#diff-2729e097eff5b2564b8ab302eed00049c9945c60d14326a6c549b01308b1b1aaL71-R80)

**Integration and Dependency Updates:**

* Updated module imports and dependency injection to wire up the new `ExternalCv` and `Media` models where needed. [[1]](diffhunk://#diff-3222b3988e9a72768128a200b634e1cc55d0f35b37242cbd5f27b11e1686510dR5-R14) [[2]](diffhunk://#diff-cd1ae76a315ab459745ebd9b6986f33c86cc73fb12bda1b45a924123bbed2e9fR1-R2) [[3]](diffhunk://#diff-c65ed0a90e06cbdb38a66351e4d624637d26142b148115d6e20df8545255e8c9R3) [[4]](diffhunk://#diff-c65ed0a90e06cbdb38a66351e4d624637d26142b148115d6e20df8545255e8c9R16)
* Updated the profile generation flow and queue processor to use the correct S3 key from the new model, ensuring compatibility and correctness. [[1]](diffhunk://#diff-6f71485239b3689bfac541c654839f7534eac8dccb431514b9906290d6ab0fedR15) [[2]](diffhunk://#diff-6f71485239b3689bfac541c654839f7534eac8dccb431514b9906290d6ab0fedL24-R26) [[3]](diffhunk://#diff-6f71485239b3689bfac541c654839f7534eac8dccb431514b9906290d6ab0fedL37-R51) [[4]](diffhunk://#diff-6f71485239b3689bfac541c654839f7534eac8dccb431514b9906290d6ab0fedL66-R75) [[5]](diffhunk://#diff-57ad5591103261d535898040cace88c72b5d63b3ac6a54f6fe975f9fea148685L72-R73)

**Scripts and Utilities:**

* Added a new script command in `package.json` for external CV migration.

These changes lay the groundwork for a more robust, auditable, and future-proof external CV management system.

[EN-9459]: https://entourage-asso.atlassian.net/browse/EN-9459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ