### PR TITLE
Add cursor pagination to conversations and handle cursor errors

### DIFF
--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -73,6 +73,11 @@ export class MessagingController {
     @Query('before') before?: string,
     @Query('after') after?: string
   ) {
+    if (before && after) {
+      throw new BadRequestException(
+        'Les paramètres before et after sont mutuellement exclusifs.'
+      );
+    }
     try {
       return await this.messagingService.getConversationById(
         conversationId,

--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -9,6 +9,7 @@ import {
   Param,
   ParseUUIDPipe,
   Post,
+  Query,
   UnauthorizedException,
   UploadedFiles,
   UseGuards,
@@ -33,6 +34,7 @@ import { UserInConversation } from './guards/user-in-conversation';
 import {
   ErrorMessagingCantParticipate,
   ErrorMessagingElearningNotCompleted,
+  ErrorMessagingInvalidCursor,
   ErrorMessagingInvalidMessage,
   ErrorMessagingMailingListInvalid,
   ErrorMessagingNeedParticipantsOrConversationId,
@@ -40,6 +42,7 @@ import {
   ErrorMessagingRecipientNotEligible,
 } from './messaging.errors';
 import { MessagingService } from './messaging.service';
+import { decodeMessageCursor } from './messaging.utils';
 
 @ApiTags('Messaging')
 @ApiBearerAuth()
@@ -66,10 +69,34 @@ export class MessagingController {
   @Get('conversations/:conversationId')
   async getConversation(
     @UserPayload('id', new ParseUUIDPipe()) userId: string,
+    @Param('conversationId', new ParseUUIDPipe()) conversationId: string,
+    @Query('before') before?: string,
+    @Query('after') after?: string
+  ) {
+    try {
+      return await this.messagingService.getConversationById(
+        conversationId,
+        userId,
+        {
+          before: before ? decodeMessageCursor(before) : undefined,
+          after: after ? decodeMessageCursor(after) : undefined,
+        }
+      );
+    } catch (error) {
+      if (error instanceof ErrorMessagingInvalidCursor) {
+        throw new BadRequestException('Cursor de pagination invalide.');
+      }
+      throw error;
+    }
+  }
+
+  @UseGuards(UserInConversation)
+  @Post('conversations/:conversationId/seen')
+  async markConversationAsSeen(
+    @UserPayload('id', new ParseUUIDPipe()) userId: string,
     @Param('conversationId', new ParseUUIDPipe()) conversationId: string
   ) {
     await this.messagingService.setConversationHasSeen(conversationId, userId);
-    return this.messagingService.getConversationById(conversationId, userId);
   }
 
   @Post('messages')

--- a/src/messaging/messaging.errors.ts
+++ b/src/messaging/messaging.errors.ts
@@ -46,3 +46,10 @@ export class ErrorMessagingRecipientNotEligible extends Error {
     this.name = 'ErrorMessagingRecipientNotEligible';
   }
 }
+
+export class ErrorMessagingInvalidCursor extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'ErrorMessagingInvalidCursor';
+  }
+}

--- a/src/messaging/messaging.includes.ts
+++ b/src/messaging/messaging.includes.ts
@@ -1,4 +1,4 @@
-import { Includeable } from 'sequelize';
+import { Includeable, Op, WhereOptions } from 'sequelize';
 import { Media } from 'src/medias/models';
 import { UserProfile } from 'src/user-profiles/models';
 import { User } from 'src/users/models';
@@ -9,6 +9,7 @@ import {
   userAttributes,
   userProfileAttributes,
 } from './messaging.attributes';
+import { MessageCursor } from './messaging.utils';
 import { Conversation, Message } from './models';
 
 export const messagingParticipantsInclude: Includeable = {
@@ -16,8 +17,37 @@ export const messagingParticipantsInclude: Includeable = {
   attributes: [...userProfileAttributes],
 };
 
+export interface MessagingConversationIncludesOptions {
+  after?: MessageCursor;
+  before?: MessageCursor;
+  limit?: number;
+}
+
+const buildMessagesCursorWhere = (
+  options: MessagingConversationIncludesOptions
+): WhereOptions | undefined => {
+  const { before, after } = options;
+  if (before) {
+    return {
+      [Op.or]: [
+        { createdAt: { [Op.lt]: before.createdAt } },
+        { createdAt: before.createdAt, id: { [Op.lt]: before.id } },
+      ],
+    };
+  }
+  if (after) {
+    return {
+      [Op.or]: [
+        { createdAt: { [Op.gt]: after.createdAt } },
+        { createdAt: after.createdAt, id: { [Op.gt]: after.id } },
+      ],
+    };
+  }
+  return undefined;
+};
+
 export const messagingConversationIncludes = (
-  limit: number | undefined = undefined
+  options: MessagingConversationIncludesOptions = {}
 ): Includeable[] => {
   return [
     {
@@ -38,8 +68,12 @@ export const messagingConversationIncludes = (
         },
       ],
       attributes: messageAttributes,
-      order: [['createdAt', 'DESC']],
-      limit: limit,
+      where: buildMessagesCursorWhere(options),
+      order: [
+        ['createdAt', 'DESC'],
+        ['id', 'DESC'],
+      ],
+      limit: options.limit,
       separate: true,
     },
     {

--- a/src/messaging/messaging.includes.ts
+++ b/src/messaging/messaging.includes.ts
@@ -49,6 +49,23 @@ const buildMessagesCursorWhere = (
 export const messagingConversationIncludes = (
   options: MessagingConversationIncludesOptions = {}
 ): Includeable[] => {
+  // With a `limit`, order determines which messages the cutoff keeps.
+  // `before`/no-cursor: DESC correctly keeps the messages nearest the
+  // cursor (the most recent). `after` needs the opposite — ASC keeps the
+  // ones nearest the cursor (the oldest of the "new" ones); DESC would
+  // instead keep only the very latest messages, silently dropping a gap
+  // of older-but-still-new ones in between. The caller (`getConversationById`)
+  // reverses the result back to the conversation's DESC-everywhere-else
+  // convention when `after` was used.
+  const order: [string, 'ASC' | 'DESC'][] = options.after
+    ? [
+        ['createdAt', 'ASC'],
+        ['id', 'ASC'],
+      ]
+    : [
+        ['createdAt', 'DESC'],
+        ['id', 'DESC'],
+      ];
   return [
     {
       model: Message,
@@ -69,10 +86,7 @@ export const messagingConversationIncludes = (
       ],
       attributes: messageAttributes,
       where: buildMessagesCursorWhere(options),
-      order: [
-        ['createdAt', 'DESC'],
-        ['id', 'DESC'],
-      ],
+      order,
       limit: options.limit,
       separate: true,
     },

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -43,6 +43,7 @@ import {
   determineIfShoudGiveFeedback,
   generateSlackMsgConfigConversationReported,
   generateSlackMsgConfigUserSuspiciousUser,
+  MessageCursor,
 } from './messaging.utils';
 import { ConversationParticipant, MessageMedia } from './models';
 import { Conversation, ConversationType } from './models/conversation.model';
@@ -74,6 +75,7 @@ export class MessagingService {
   ) {}
 
   private readonly DAILY_CONVERSATION_LIMIT_THRESHOLD = 8;
+  private readonly DEFAULT_MESSAGES_PAGE_SIZE = 30;
 
   async createMessageWithConversation(
     createMessageDto: CreateMessageDto,
@@ -274,7 +276,7 @@ export class MessagingService {
           {
             model: Conversation,
             as: 'conversation',
-            include: [...messagingConversationIncludes(10)],
+            include: [...messagingConversationIncludes({ limit: 10 })],
           },
         ],
         order: [
@@ -322,12 +324,19 @@ export class MessagingService {
   }
 
   /**
-   * Get a conversation by its ID
+   * Get a conversation by its ID, with its messages paginated by cursor.
    * @param conversationId - The ID of the conversation to fetch
    * @param userId - The ID of the user fetching the conversation
+   * @param cursor - `before`: the 30 messages preceding it (older page, infinite scroll).
+   *                 `after`: every message following it, unbounded (polling delta).
+   *                 Neither: the 30 most recent messages (initial load).
    * @returns The conversation if the user is a participant, otherwise null
    */
-  async getConversationById(conversationId: string, userId: string) {
+  async getConversationById(
+    conversationId: string,
+    userId: string,
+    cursor?: { before?: MessageCursor; after?: MessageCursor }
+  ) {
     const conversationParticipants =
       await this.conversationParticipantModel.findAll({
         where: {
@@ -338,7 +347,15 @@ export class MessagingService {
           {
             model: Conversation,
             as: 'conversation',
-            include: [...messagingConversationIncludes()],
+            include: [
+              ...messagingConversationIncludes({
+                before: cursor?.before,
+                after: cursor?.after,
+                limit: cursor?.after
+                  ? undefined
+                  : this.DEFAULT_MESSAGES_PAGE_SIZE,
+              }),
+            ],
           },
         ],
       });

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -76,6 +76,7 @@ export class MessagingService {
 
   private readonly DAILY_CONVERSATION_LIMIT_THRESHOLD = 8;
   private readonly DEFAULT_MESSAGES_PAGE_SIZE = 30;
+  private readonly MAX_MESSAGES_PAGE_SIZE = 200;
 
   async createMessageWithConversation(
     createMessageDto: CreateMessageDto,
@@ -328,7 +329,7 @@ export class MessagingService {
    * @param conversationId - The ID of the conversation to fetch
    * @param userId - The ID of the user fetching the conversation
    * @param cursor - `before`: the 30 messages preceding it (older page, infinite scroll).
-   *                 `after`: every message following it, unbounded (polling delta).
+   *                 `after`: every message following it, up to 200 (polling delta).
    *                 Neither: the 30 most recent messages (initial load).
    * @returns The conversation if the user is a participant, otherwise null
    */
@@ -352,7 +353,7 @@ export class MessagingService {
                 before: cursor?.before,
                 after: cursor?.after,
                 limit: cursor?.after
-                  ? undefined
+                  ? this.MAX_MESSAGES_PAGE_SIZE
                   : this.DEFAULT_MESSAGES_PAGE_SIZE,
               }),
             ],
@@ -364,6 +365,13 @@ export class MessagingService {
 
     if (!cp) {
       return null;
+    }
+
+    if (cursor?.after) {
+      // Queried ASC (nearest-to-cursor-first) so the limit keeps the
+      // right messages — see messagingConversationIncludes. Reverse back
+      // to the newest-first order used everywhere else.
+      cp.conversation.messages.reverse();
     }
 
     const shouldGiveFeedback = determineIfShoudGiveFeedback(

--- a/src/messaging/messaging.utils.ts
+++ b/src/messaging/messaging.utils.ts
@@ -1,7 +1,47 @@
 import { SlackBlockConfig } from 'src/external-services/slack/slack.types';
 import { User } from 'src/users/models';
-import { ErrorMessagingMailingListInvalid } from './messaging.errors';
+import {
+  ErrorMessagingInvalidCursor,
+  ErrorMessagingMailingListInvalid,
+} from './messaging.errors';
 import { Conversation, ConversationType } from './models';
+
+export interface MessageCursor {
+  createdAt: Date;
+  id: string;
+}
+
+const CURSOR_SEPARATOR = '_';
+
+/**
+ * Encodes a message's `(createdAt, id)` as a single opaque pagination
+ * cursor, so the client never has to synchronize two query params.
+ */
+export const encodeMessageCursor = (cursor: MessageCursor): string => {
+  return Buffer.from(
+    `${cursor.createdAt.toISOString()}${CURSOR_SEPARATOR}${cursor.id}`
+  ).toString('base64');
+};
+
+export const decodeMessageCursor = (rawCursor: string): MessageCursor => {
+  let decoded: string;
+  try {
+    decoded = Buffer.from(rawCursor, 'base64').toString('utf-8');
+  } catch {
+    throw new ErrorMessagingInvalidCursor();
+  }
+  const separatorIndex = decoded.lastIndexOf(CURSOR_SEPARATOR);
+  if (separatorIndex === -1) {
+    throw new ErrorMessagingInvalidCursor();
+  }
+  const createdAtIso = decoded.slice(0, separatorIndex);
+  const id = decoded.slice(separatorIndex + 1);
+  const createdAt = new Date(createdAtIso);
+  if (Number.isNaN(createdAt.getTime()) || !id) {
+    throw new ErrorMessagingInvalidCursor();
+  }
+  return { createdAt, id };
+};
 
 export const generateSlackMsgConfigConversationReported = (
   conversation: Conversation,

--- a/src/messaging/messaging.utils.ts
+++ b/src/messaging/messaging.utils.ts
@@ -1,3 +1,4 @@
+import { isUUID } from 'class-validator';
 import { SlackBlockConfig } from 'src/external-services/slack/slack.types';
 import { User } from 'src/users/models';
 import {
@@ -16,17 +17,21 @@ const CURSOR_SEPARATOR = '_';
 /**
  * Encodes a message's `(createdAt, id)` as a single opaque pagination
  * cursor, so the client never has to synchronize two query params.
+ * `base64url` (not plain `base64`) so the result is safe to interpolate
+ * directly into a query string: plain base64's `+`/`/`/`=` would
+ * otherwise need percent-encoding, and a `+` left as-is is silently
+ * read back as a space by query-string parsers.
  */
 export const encodeMessageCursor = (cursor: MessageCursor): string => {
   return Buffer.from(
     `${cursor.createdAt.toISOString()}${CURSOR_SEPARATOR}${cursor.id}`
-  ).toString('base64');
+  ).toString('base64url');
 };
 
 export const decodeMessageCursor = (rawCursor: string): MessageCursor => {
   let decoded: string;
   try {
-    decoded = Buffer.from(rawCursor, 'base64').toString('utf-8');
+    decoded = Buffer.from(rawCursor, 'base64url').toString('utf-8');
   } catch {
     throw new ErrorMessagingInvalidCursor();
   }
@@ -37,7 +42,7 @@ export const decodeMessageCursor = (rawCursor: string): MessageCursor => {
   const createdAtIso = decoded.slice(0, separatorIndex);
   const id = decoded.slice(separatorIndex + 1);
   const createdAt = new Date(createdAtIso);
-  if (Number.isNaN(createdAt.getTime()) || !id) {
+  if (Number.isNaN(createdAt.getTime()) || !isUUID(id, 4)) {
     throw new ErrorMessagingInvalidCursor();
   }
   return { createdAt, id };

--- a/tests/messaging/messaging.e2e-spec.ts
+++ b/tests/messaging/messaging.e2e-spec.ts
@@ -5,6 +5,7 @@ import { UsersHelper, LoggedInUser } from '../users/users.helper';
 import { SlackService } from 'src/external-services/slack/slack.service';
 import { MessagingController } from 'src/messaging/messaging.controller';
 import { MessagingService } from 'src/messaging/messaging.service';
+import { encodeMessageCursor } from 'src/messaging/messaging.utils';
 import { ConversationType } from 'src/messaging/models/conversation.model';
 import { QueuesService } from 'src/queues/producers/queues.service';
 import { User } from 'src/users/models';
@@ -902,6 +903,234 @@ describe('MESSAGING', () => {
 
           const response = await request(server).get(
             `/messaging/conversations/${conversation.id}`
+          );
+
+          expect(response.status).toBe(401);
+        });
+
+        describe('Pagination', () => {
+          // Oldest first, spaced one minute apart, to control ordering deterministically.
+          const createSequentialMessages = async (
+            conversationId: string,
+            authorId: string,
+            count: number
+          ) => {
+            const messages = [];
+            for (let i = 0; i < count; i++) {
+              messages.push(
+                await messagingHelper.createMessage(conversationId, authorId, {
+                  createdAt: new Date(Date.now() - (count - i) * 60000),
+                  updatedAt: new Date(Date.now() - (count - i) * 60000),
+                })
+              );
+            }
+            return messages;
+          };
+
+          it('should return only the 30 most recent messages when no cursor is provided', async () => {
+            const conversation = await conversationFactory.create();
+            await messagingHelper.associationParticipantsToConversation(
+              conversation.id,
+              [loggedInCandidate.user.id, loggedInCoach.user.id]
+            );
+            const messages = await createSequentialMessages(
+              conversation.id,
+              loggedInCandidate.user.id,
+              35
+            );
+
+            const response: APIResponse<
+              MessagingController['getConversation']
+            > = await request(server)
+              .get(`/messaging/conversations/${conversation.id}`)
+              .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+            expect(response.status).toBe(200);
+            expect(response.body.messages.length).toBe(30);
+            // Messages are returned newest-first.
+            expect(response.body.messages[0].id).toBe(messages[34].id);
+            expect(response.body.messages[29].id).toBe(messages[5].id);
+          });
+
+          it('should return the 30 messages preceding the given `before` cursor', async () => {
+            const conversation = await conversationFactory.create();
+            await messagingHelper.associationParticipantsToConversation(
+              conversation.id,
+              [loggedInCandidate.user.id, loggedInCoach.user.id]
+            );
+            const messages = await createSequentialMessages(
+              conversation.id,
+              loggedInCandidate.user.id,
+              35
+            );
+            const oldestLoadedMessage = messages[5]; // 30th (index 5..34) message currently loaded
+            const cursor = encodeMessageCursor({
+              createdAt: new Date(oldestLoadedMessage.createdAt),
+              id: oldestLoadedMessage.id,
+            });
+
+            const response: APIResponse<
+              MessagingController['getConversation']
+            > = await request(server)
+              .get(
+                `/messaging/conversations/${conversation.id}?before=${cursor}`
+              )
+              .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+            expect(response.status).toBe(200);
+            expect(response.body.messages.length).toBe(5);
+            expect(response.body.messages[0].id).toBe(messages[4].id);
+            expect(response.body.messages[4].id).toBe(messages[0].id);
+          });
+
+          it('should return every message after the given `after` cursor, unbounded', async () => {
+            const conversation = await conversationFactory.create();
+            await messagingHelper.associationParticipantsToConversation(
+              conversation.id,
+              [loggedInCandidate.user.id, loggedInCoach.user.id]
+            );
+            const messages = await createSequentialMessages(
+              conversation.id,
+              loggedInCandidate.user.id,
+              35
+            );
+            const mostRecentKnownMessage = messages[4];
+            const cursor = encodeMessageCursor({
+              createdAt: new Date(mostRecentKnownMessage.createdAt),
+              id: mostRecentKnownMessage.id,
+            });
+
+            const response: APIResponse<
+              MessagingController['getConversation']
+            > = await request(server)
+              .get(
+                `/messaging/conversations/${conversation.id}?after=${cursor}`
+              )
+              .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+            expect(response.status).toBe(200);
+            expect(response.body.messages.length).toBe(30);
+            expect(response.body.messages[0].id).toBe(messages[34].id);
+            expect(response.body.messages[29].id).toBe(messages[5].id);
+          });
+
+          it('should return 400 for an invalid cursor', async () => {
+            const conversation = await conversationFactory.create();
+            await messagingHelper.associationParticipantsToConversation(
+              conversation.id,
+              [loggedInCandidate.user.id, loggedInCoach.user.id]
+            );
+
+            const response = await request(server)
+              .get(
+                `/messaging/conversations/${conversation.id}?before=not-a-cursor`
+              )
+              .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+            expect(response.status).toBe(400);
+          });
+
+          it('should not mark the conversation as seen', async () => {
+            const conversation = await conversationFactory.create();
+            await messagingHelper.associationParticipantsToConversation(
+              conversation.id,
+              [loggedInCandidate.user.id, loggedInCoach.user.id]
+            );
+            await messagingHelper.createMessage(
+              conversation.id,
+              loggedInCoach.user.id
+            );
+
+            await request(server)
+              .get(`/messaging/conversations/${conversation.id}`)
+              .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+            const participant =
+              await messagingHelper.findConversationParticipant(
+                conversation.id,
+                loggedInCandidate.user.id
+              );
+            expect(participant.seenAt).toBeNull();
+          });
+        });
+      });
+
+      describe('U - Mark conversation as seen - /messaging/conversations/:id/seen', () => {
+        it('should return 201 and set seenAt to now', async () => {
+          const conversation = await conversationFactory.create();
+          await messagingHelper.associationParticipantsToConversation(
+            conversation.id,
+            [loggedInCandidate.user.id, loggedInCoach.user.id]
+          );
+
+          const response = await request(server)
+            .post(`/messaging/conversations/${conversation.id}/seen`)
+            .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+          expect(response.status).toBe(201);
+          const participant = await messagingHelper.findConversationParticipant(
+            conversation.id,
+            loggedInCandidate.user.id
+          );
+          expect(participant.seenAt).not.toBeNull();
+        });
+
+        it('should return 201 and update seenAt again when called with no new message', async () => {
+          const conversation = await conversationFactory.create();
+          await messagingHelper.associationParticipantsToConversation(
+            conversation.id,
+            [loggedInCandidate.user.id, loggedInCoach.user.id]
+          );
+
+          await request(server)
+            .post(`/messaging/conversations/${conversation.id}/seen`)
+            .set('authorization', `Bearer ${loggedInCandidate.token}`);
+          const firstSeenAt = (
+            await messagingHelper.findConversationParticipant(
+              conversation.id,
+              loggedInCandidate.user.id
+            )
+          ).seenAt;
+
+          const response = await request(server)
+            .post(`/messaging/conversations/${conversation.id}/seen`)
+            .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+          expect(response.status).toBe(201);
+          const secondSeenAt = (
+            await messagingHelper.findConversationParticipant(
+              conversation.id,
+              loggedInCandidate.user.id
+            )
+          ).seenAt;
+          expect(secondSeenAt.getTime()).toBeGreaterThanOrEqual(
+            firstSeenAt.getTime()
+          );
+        });
+
+        it('should return 401 if the user is not a participant of the conversation', async () => {
+          const conversation = await conversationFactory.create();
+          await messagingHelper.associationParticipantsToConversation(
+            conversation.id,
+            [loggedInOtherCandidate.user.id, loggedInCoach.user.id]
+          );
+
+          const response = await request(server)
+            .post(`/messaging/conversations/${conversation.id}/seen`)
+            .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+          expect(response.status).toBe(401);
+        });
+
+        it('should return 401 if the user is not logged in', async () => {
+          const conversation = await conversationFactory.create();
+          await messagingHelper.associationParticipantsToConversation(
+            conversation.id,
+            [loggedInCandidate.user.id, loggedInCoach.user.id]
+          );
+
+          const response = await request(server).post(
+            `/messaging/conversations/${conversation.id}/seen`
           );
 
           expect(response.status).toBe(401);

--- a/tests/messaging/messaging.e2e-spec.ts
+++ b/tests/messaging/messaging.e2e-spec.ts
@@ -994,10 +994,10 @@ describe('MESSAGING', () => {
               loggedInCandidate.user.id,
               35
             );
-            const mostRecentKnownMessage = messages[4];
+            const lastKnownMessage = messages[4];
             const cursor = encodeMessageCursor({
-              createdAt: new Date(mostRecentKnownMessage.createdAt),
-              id: mostRecentKnownMessage.id,
+              createdAt: new Date(lastKnownMessage.createdAt),
+              id: lastKnownMessage.id,
             });
 
             const response: APIResponse<
@@ -1028,6 +1028,66 @@ describe('MESSAGING', () => {
               .set('authorization', `Bearer ${loggedInCandidate.token}`);
 
             expect(response.status).toBe(400);
+          });
+
+          it('should return 400 when both before and after are provided', async () => {
+            const conversation = await conversationFactory.create();
+            await messagingHelper.associationParticipantsToConversation(
+              conversation.id,
+              [loggedInCandidate.user.id, loggedInCoach.user.id]
+            );
+            const message = await messagingHelper.createMessage(
+              conversation.id,
+              loggedInCandidate.user.id
+            );
+            const cursor = encodeMessageCursor({
+              createdAt: new Date(message.createdAt),
+              id: message.id,
+            });
+
+            const response = await request(server)
+              .get(
+                `/messaging/conversations/${conversation.id}?before=${cursor}&after=${cursor}`
+              )
+              .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+            expect(response.status).toBe(400);
+          });
+
+          it('should cap `after` results to the messages nearest the cursor, not the newest ones, once the cap is exceeded', async () => {
+            const conversation = await conversationFactory.create();
+            await messagingHelper.associationParticipantsToConversation(
+              conversation.id,
+              [loggedInCandidate.user.id, loggedInCoach.user.id]
+            );
+            const messages = await createSequentialMessages(
+              conversation.id,
+              loggedInCandidate.user.id,
+              210
+            );
+            const lastKnownMessage = messages[4];
+            const cursor = encodeMessageCursor({
+              createdAt: new Date(lastKnownMessage.createdAt),
+              id: lastKnownMessage.id,
+            });
+
+            const response: APIResponse<
+              MessagingController['getConversation']
+            > = await request(server)
+              .get(
+                `/messaging/conversations/${conversation.id}?after=${cursor}`
+              )
+              .set('authorization', `Bearer ${loggedInCandidate.token}`);
+
+            expect(response.status).toBe(200);
+            expect(response.body.messages.length).toBe(200);
+            // Newest-first: the 200 messages nearest the cursor are
+            // [5..204], not the 200 most recent ones ([10..209]) — a
+            // naive DESC-ordered query with a limit would instead return
+            // the latter, silently dropping everything right after the
+            // cursor.
+            expect(response.body.messages[0].id).toBe(messages[204].id);
+            expect(response.body.messages[199].id).toBe(messages[5].id);
           });
 
           it('should not mark the conversation as seen', async () => {

--- a/tests/messaging/messaging.helper.ts
+++ b/tests/messaging/messaging.helper.ts
@@ -68,6 +68,12 @@ export class MessagingHelper {
     return this.conversationModel.count();
   }
 
+  async findConversationParticipant(conversationId: string, userId: string) {
+    return this.conversationParticipantModel.findOne({
+      where: { conversationId, userId },
+    });
+  }
+
   async findConversation(conversationId: string) {
     return this.conversationModel.findByPk(conversationId, {
       include: [


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9460](https://entourage-asso.atlassian.net/browse/EN-9460)
**🚧 PR-Front :** [front/743](https://github.com/ReseauEntourage/entourage-job-front/pull/743)
**💬 Commentaire :**

This pull request introduces cursor-based pagination for messages within conversations, enhancing the messaging API's scalability and user experience. It adds support for fetching messages before or after a given message, improves error handling for invalid pagination cursors, and decouples message retrieval from marking conversations as seen. The changes are thoroughly tested with new end-to-end tests covering all pagination scenarios and conversation-seen logic.

**API and Pagination Enhancements:**

* Added cursor-based pagination to the `getConversation` endpoint in `MessagingController`, supporting `before` and `after` query parameters for efficient message retrieval. The endpoint now returns the 30 most recent messages by default, 30 older messages with `before`, or all newer messages with `after`. Invalid cursors return a 400 error. (`src/messaging/messaging.controller.ts`, `src/messaging/messaging.service.ts`, `src/messaging/messaging.includes.ts`, `src/messaging/messaging.utils.ts`, [[1]](diffhunk://#diff-0ecf2ba7c7238e8b26eb6fb34b9afec7ab003d515f9fec6034196eced83cb47fR71-L72) [[2]](diffhunk://#diff-0ecf2ba7c7238e8b26eb6fb34b9afec7ab003d515f9fec6034196eced83cb47fR37-R45) [[3]](diffhunk://#diff-e7599fbbd302c5739c5afc1e12f10f0ee2da18ce7666fcd9f058a3c4f9f3ae27R12-R50) [[4]](diffhunk://#diff-e7599fbbd302c5739c5afc1e12f10f0ee2da18ce7666fcd9f058a3c4f9f3ae27L41-R76) [[5]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61L325-R339) [[6]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61L341-R358) [[7]](diffhunk://#diff-c08f519cf1701a57f1b856f7cb2880437cc5ebd2eb54949bab0da786296f5e61R78) [[8]](diffhunk://#diff-e2adfee0ef2995e91dda468051d6fc5779e71708d5385cad9b2d8dfc7b413888L3-R45) [[9]](diffhunk://#diff-58e001bded536aae53d7da8f391a45f58496ad27868b1f9cb4e0bb3a20b74dc6R49-R55)

* Introduced the `MessageCursor` type and helper functions `encodeMessageCursor` and `decodeMessageCursor` to safely encode/decode message cursors for pagination. (`src/messaging/messaging.utils.ts`, [src/messaging/messaging.utils.tsL3-R45](diffhunk://#diff-e2adfee0ef2995e91dda468051d6fc5779e71708d5385cad9b2d8dfc7b413888L3-R45))

**Error Handling:**

* Added `ErrorMessagingInvalidCursor` error class and integrated it into the controller to handle and report invalid cursor errors as HTTP 400 responses. (`src/messaging/messaging.errors.ts`, `src/messaging/messaging.controller.ts`, [[1]](diffhunk://#diff-58e001bded536aae53d7da8f391a45f58496ad27868b1f9cb4e0bb3a20b74dc6R49-R55) [[2]](diffhunk://#diff-0ecf2ba7c7238e8b26eb6fb34b9afec7ab003d515f9fec6034196eced83cb47fR37-R45) [[3]](diffhunk://#diff-0ecf2ba7c7238e8b26eb6fb34b9afec7ab003d515f9fec6034196eced83cb47fR71-L72)

**Conversation Seen Logic:**

* Separated marking a conversation as seen into its own endpoint (`POST /messaging/conversations/:conversationId/seen`), ensuring that simply fetching messages does not update the seen status. (`src/messaging/messaging.controller.ts`, [src/messaging/messaging.controller.tsR71-L72](diffhunk://#diff-0ecf2ba7c7238e8b26eb6fb34b9afec7ab003d515f9fec6034196eced83cb47fR71-L72))

**Testing Improvements:**

* Added comprehensive end-to-end tests for message pagination and conversation seen logic, including tests for correct message ordering, cursor behavior, error handling, and seen status updates. (`tests/messaging/messaging.e2e-spec.ts`, `tests/messaging/messaging.helper.ts`, [[1]](diffhunk://#diff-35123517d38609f9e2be171fa6b2b5285ddf8a7cb41191d7402a0612a93f9e3bR910-R1137) [[2]](diffhunk://#diff-213c1777ac1895a9b2630dc85addadc5e983f0cf541b251cdd280f118f839f1dR71-R76)

These changes collectively provide a more robust, scalable, and user-friendly messaging experience.

[EN-9460]: https://entourage-asso.atlassian.net/browse/EN-9460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ